### PR TITLE
AAU, on API, when I use a method using asset_id as parameter, I see it also accepts external_id

### DIFF
--- a/kili/helpers.py
+++ b/kili/helpers.py
@@ -173,11 +173,11 @@ def infer_id_from_external_id(playground, asset_id: str, external_id: str, proje
     if asset_id is not None:
         return asset_id
     assets = playground.assets(
-        external_id=external_id, project_id=project_id, fields=['id'], disable_tqdm=True)
+        external_id_contains=[external_id], project_id=project_id, fields=['id'], disable_tqdm=True)
     if len(assets) == 0:
         raise Exception(
             f'No asset found with external ID "{external_id}"')
     if len(assets) > 1:
         raise Exception(
-            f'Several assets found with external ID "{external_id}": {assets}')
+            f'Several assets found containing external ID "{external_id}": {assets}. Please, use asset ID instead.')
     return assets[0]['id']

--- a/kili/helpers.py
+++ b/kili/helpers.py
@@ -164,3 +164,20 @@ def is_none_or_empty(object):
 
 def list_is_not_none_else_none(object):
     return [object] if object is not None else None
+
+
+def infer_id_from_external_id(playground, asset_id: str, external_id: str, project_id: str):
+    if asset_id is None and external_id is None:
+        raise Exception(
+            'Either provide asset_id or external_id and project_id')
+    if asset_id is not None:
+        return asset_id
+    assets = playground.assets(
+        external_id=external_id, project_id=project_id, fields=['id'], disable_tqdm=True)
+    if len(assets) == 0:
+        raise Exception(
+            f'No asset found with external ID "{external_id}"')
+    if len(assets) > 1:
+        raise Exception(
+            f'Several assets found with external ID "{external_id}": {assets}')
+    return assets[0]['id']

--- a/kili/mutations/label/__init__.py
+++ b/kili/mutations/label/__init__.py
@@ -111,7 +111,7 @@ class MutationsLabel:
         if author_id is None:
             author_id = self.auth.user_id
         label_asset_id = infer_id_from_external_id(
-            self.auth.playground, label_asset_id, label_asset_external_id, project_id)
+            self, label_asset_id, label_asset_external_id, project_id)
         variables = {
             'authorID': author_id,
             'jsonResponse': dumps(json_response),
@@ -184,7 +184,7 @@ class MutationsLabel:
         - a result object which indicates if the mutation was successful, or an error message else.
         """
         asset_id = infer_id_from_external_id(
-            self.auth.playground, asset_id, asset_external_id, project_id)
+            self, asset_id, asset_external_id, project_id)
         variables = {
             'assetID': asset_id,
             'jsonResponse': dumps(json_response)

--- a/kili/mutations/label/__init__.py
+++ b/kili/mutations/label/__init__.py
@@ -1,7 +1,7 @@
 from json import dumps
 from typing import List
 
-from ...helpers import Compatible, format_result
+from ...helpers import Compatible, format_result, infer_id_from_external_id
 from .queries import (GQL_APPEND_TO_LABELS, GQL_CREATE_HONEYPOT,
                       GQL_CREATE_PREDICTIONS,
                       GQL_UPDATE_PROPERTIES_IN_LABEL)
@@ -76,7 +76,7 @@ class MutationsLabel:
         return format_result('data', result)
 
     @Compatible(['v1', 'v2'])
-    def append_to_labels(self, json_response: dict, label_asset_id: str, author_id: str = None, label_type: str = 'DEFAULT', seconds_to_label: int = 0, skipped: bool = False):
+    def append_to_labels(self, json_response: dict, author_id: str = None, label_asset_external_id: str = None, label_asset_id: str = None, label_type: str = 'DEFAULT', project_id: str = None, seconds_to_label: int = 0, skipped: bool = False):
         """
         Append a label to an asset
 
@@ -84,10 +84,17 @@ class MutationsLabel:
         ----------
         - json_response : dict
             Label is given here
-        - label_asset_id : str
-            Identifier of the asset
         - author_id : str, optional (default = auth.user_id)
             ID of the author of the label
+        - label_asset_external_id : str, optional (default = None)
+            External identifier of the asset
+            Either provide label_asset_id or label_asset_external_id and project_id
+        - label_asset_id : str, optional (default = None)
+            Identifier of the asset
+            Either provide label_asset_id or label_asset_external_id and project_id
+        - project_id : str, optional (default = None)
+            Project ID of the asset
+            Either provide label_asset_id or label_asset_external_id and project_id
         - label_type : str, optional (default = 'DEFAULT')
             Can be one of {'AUTOSAVE', 'DEFAULT', 'PREDICTION', 'REVIEW'}
         - seconds_to_label : int, optional (default = 0)
@@ -103,6 +110,8 @@ class MutationsLabel:
         """
         if author_id is None:
             author_id = self.auth.user_id
+        label_asset_id = infer_id_from_external_id(
+            self.auth.playground, label_asset_id, label_asset_external_id, project_id)
         variables = {
             'authorID': author_id,
             'jsonResponse': dumps(json_response),
@@ -149,7 +158,7 @@ class MutationsLabel:
         return format_result('data', result)
 
     @Compatible(['v1', 'v2'])
-    def create_honeypot(self, asset_id: str, json_response: dict):
+    def create_honeypot(self, json_response: dict, asset_external_id: str = None, asset_id: str = None, project_id: str = None):
         """
         Create honeypot for an asset. 
 
@@ -158,15 +167,24 @@ class MutationsLabel:
 
         Parameters
         ----------
-        - asset_id : str
-            Identifier of the asset
         - json_response : dict
-            The honeypot label of the asset
+            The JSON response of the honeypot label of the asset
+        - asset_id : str, optional (default = None)
+            Identifier of the asset
+            Either provide asset_id or asset_external_id and project_id
+        - asset_external_id : str, optional (default = None)
+            External identifier of the asset
+            Either provide asset_id or asset_external_id and project_id
+        - project_id : str, optional (default = None)
+            External identifier of the asset
+            Either provide asset_id or asset_external_id and project_id
 
         Returns
         -------
         - a result object which indicates if the mutation was successful, or an error message else.
         """
+        asset_id = infer_id_from_external_id(
+            self.auth.playground, asset_id, asset_external_id, project_id)
         variables = {
             'assetID': asset_id,
             'jsonResponse': dumps(json_response)

--- a/kili/playground.py
+++ b/kili/playground.py
@@ -35,7 +35,7 @@ class Playground(
         kili.queries.user.QueriesUser,
         kili.subscriptions.label.SubscriptionsLabel):
 
-    def __init__(self, auth=None):
+    def __init__(self, auth=None, playground=None):
         """Create an instance of KiliPlayground."""
         self.auth = auth
         super().__init__(auth)


### PR DESCRIPTION
- [ ] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests
