### PR TITLE
AAU, on label-frontend and Kili Playground, when I search for "jsonCo…

### DIFF
--- a/kili/helpers.py
+++ b/kili/helpers.py
@@ -95,7 +95,7 @@ def format_json(result):
             if key in ['jsonInterface', 'jsonMetadata', 'jsonResponse']:
                 if (value == '' or value is None) and not (is_url(value) and key == 'jsonInterface'):
                     result[key] = dict()
-                else:
+                elif isinstance(value, str):
                     try:
                         if is_url(value):
                             result[key] = requests.get(value).json()

--- a/kili/types.py
+++ b/kili/types.py
@@ -62,7 +62,9 @@ class ProjectWithoutDataset(object):
     honeypotMark = 'honeypotMark'
     inputType = 'inputType'
     instructions = 'instructions'
+    interface = 'interface'
     interfaceCategory = 'interfaceCategory'
+    interfaceCompute = 'interfaceCompute'
     jsonInterface = 'jsonInterface'
     maxWorkerCount = 'maxWorkerCount'
     minAgreement = 'minAgreement'
@@ -151,6 +153,8 @@ class Asset(object):
     consensusMark = 'consensusMark'
     consensusMarkCompute = 'consensusMarkCompute'
     content = 'content'
+    contentJson = 'contentJson'
+    contentJsonCompute = 'contentJsonCompute'
     createdAt = 'createdAt'
     duration = 'duration'
     durationCompute = 'durationCompute'
@@ -165,6 +169,8 @@ class Asset(object):
     jsonMetadata = 'jsonMetadata'
     labels = LabelWithoutLabelOf
     locks = Lock
+    metadataCompute = 'metadataCompute'
+    metadata = 'metadata'
     numberOfValidLocks = 'numberOfValidLocks'
     numberOfValidLocksCompute = 'numberOfValidLocksCompute'
     priority = 'priority'


### PR DESCRIPTION
…ntent", I see it uses the JSONB fields instead

- [x] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests
