### PR TITLE
[INFERENCE] AAU, on API, when I insert inference labels on an asset with existing labels, I see an inference mark

### DIFF
--- a/kili/mutations/label/__init__.py
+++ b/kili/mutations/label/__init__.py
@@ -84,8 +84,8 @@ class MutationsLabel:
     def append_to_labels(self, json_response: dict, author_id: Optional[str] = None, 
             label_asset_external_id: Optional[str] = None, 
             label_asset_id: Optional[str] = None, label_type: str = 'DEFAULT', 
-            project_id: Optional[str] = None, seconds_to_label: int = 0, 
-            skipped: bool = False):
+            project_id: Optional[str] = None, seconds_to_label: Optional[int] = 0, 
+            skipped: Optional[bool] = False):
         """
         Append a label to an asset
 

--- a/kili/types.py
+++ b/kili/types.py
@@ -104,6 +104,8 @@ class LabelWithoutLabelOf(object):
     createdAt = 'createdAt'
     honeypotMark = 'honeypotMark'
     honeypotMarkCompute = 'honeypotMarkCompute'
+    inferenceMark = 'inferenceMark'
+    inferenceMarkCompute = 'inferenceMarkCompute'
     isLatestLabelForUser = 'isLatestLabelForUser'
     isLatestLabelForUserCompute = 'isLatestLabelForUserCompute'
     isLatestDefaultLabelForUser = 'isLatestDefaultLabelForUser'

--- a/kili/types.py
+++ b/kili/types.py
@@ -168,6 +168,8 @@ class Asset(object):
     externalId = 'externalId'
     honeypotMark = 'honeypotMark'
     honeypotMarkCompute = 'honeypotMarkCompute'
+    inferenceMark = 'inferenceMark'
+    inferenceMarkCompute = 'inferenceMarkCompute'
     isHoneypot = 'isHoneypot'
     isToBeLabeledByCompute = 'isToBeLabeledByCompute'
     issues = Issues


### PR DESCRIPTION
- [x] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests
