### PR TITLE
Keep internal method "__delete_project" for internal use by Kili

### DIFF
--- a/kili/mutations/project/__init__.py
+++ b/kili/mutations/project/__init__.py
@@ -9,7 +9,7 @@ from ...queries.project import QueriesProject
 from .queries import (GQL_APPEND_TO_ROLES,
                       GQL_CREATE_PROJECT,
                       GQL_DELETE_FROM_ROLES,
-                      GQL_PROJECT_DELETE,
+                      GQL_DELETE_PROJECT,
                       GQL_PROJECT_DELETE_ASYNCHRONOUSLY,
                       GQL_MAKE_PROJECT_PUBLIC,
                       GQL_GQL_UPDATE_PROPERTIES_IN_PROJECT_USER,
@@ -351,7 +351,7 @@ class MutationsProject:
         - a result object which indicates if the mutation was successful, or an error message else.
         """
         variables = {'projectID': project_id}
-        result = self.auth.client.execute(GQL_PROJECT_DELETE, variables)
+        result = self.auth.client.execute(GQL_DELETE_PROJECT, variables)
         return format_result('data', result)
 
     @Compatible(['v1', 'v2'])

--- a/kili/mutations/project/__init__.py
+++ b/kili/mutations/project/__init__.py
@@ -9,6 +9,7 @@ from ...queries.project import QueriesProject
 from .queries import (GQL_APPEND_TO_ROLES,
                       GQL_CREATE_PROJECT,
                       GQL_DELETE_FROM_ROLES,
+                      GQL_PROJECT_DELETE,
                       GQL_PROJECT_DELETE_ASYNCHRONOUSLY,
                       GQL_MAKE_PROJECT_PUBLIC,
                       GQL_GQL_UPDATE_PROPERTIES_IN_PROJECT_USER,
@@ -337,9 +338,27 @@ class MutationsProject:
 
     @Compatible(['v1', 'v2'])
     @typechecked
+    def __delete_project(self, project_id: str):
+        """
+        Delete project permanently. WARNING: This resolver is for internal use by Kili Technology only.
+
+        Parameters
+        ----------
+        - project_id : str
+
+        Returns
+        -------
+        - a result object which indicates if the mutation was successful, or an error message else.
+        """
+        variables = {'projectID': project_id}
+        result = self.auth.client.execute(GQL_PROJECT_DELETE, variables)
+        return format_result('data', result)
+
+    @Compatible(['v1', 'v2'])
+    @typechecked
     def delete_project(self, project_id: str):
         """
-        Delete project permanently 
+        Delete project permanently.
 
         Parameters
         ----------

--- a/kili/mutations/project/__init__.py
+++ b/kili/mutations/project/__init__.py
@@ -338,7 +338,7 @@ class MutationsProject:
 
     @Compatible(['v1', 'v2'])
     @typechecked
-    def __delete_project(self, project_id: str):
+    def internal_delete_project(self, project_id: str):
         """
         Delete project permanently. WARNING: This resolver is for internal use by Kili Technology only.
 

--- a/kili/mutations/project/queries.py
+++ b/kili/mutations/project/queries.py
@@ -146,6 +146,17 @@ mutation(
 }}
 '''
 
+GQL_DELETE_PROJECT = f'''
+mutation($projectID: ID!) {{
+  data: deleteProject(where: {{
+      id: $projectID
+    }}
+    ) {{
+    {PROJECT_FRAGMENT_ID}
+  }}
+}}
+'''
+
 GQL_PROJECT_DELETE_ASYNCHRONOUSLY = f'''
 mutation($projectID: ID!) {{
   data: deleteProjectAsynchronously(where: {{


### PR DESCRIPTION
- [x] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests
