### PR TITLE
AAU on Kili, when I set up KILI_API_KEY, I see it I can directly use kili = Kili()

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## What is Kili Technology?
 
-Kili Technology is an image, text and voice data annotation tool designed to help companies deploy machine learning applications faster. In a few minutes you can start annotating your data thanks to a catalogue of intuitive and configurable interfaces. You can easily accelerate the labeling process by connecting one of your models to pre annotate the data. The work of the annotators is 2 to 5 times faster. Kili Technology facilitates collaboration between technical teams and the business, but also with outsourced annotation companies. Data governance is managed, and production quality control is facilitated. Kili Technology meets the needs of small teams as well as those of large companies with massive stakes.
+Kili Technology is an image, text, and voice data annotation tool designed to help companies deploy machine learning applications faster. In a few minutes, you can start annotating your data thanks to a catalog of intuitive and configurable interfaces. You can easily accelerate the labeling process by connecting one of your models to pre-annotate the data. The work of the annotators is 2 to 5 times faster. Kili Technology facilitates collaboration between technical teams and the business, but also with outsourced annotation companies. Data governance is managed, and production quality control is facilitated. Kili Technology meets the needs of small teams as well as those of large companies with massive stakes.
 
 Kili Technology allows you to:
 
@@ -39,7 +39,7 @@ Kili Technology allows you to:
 | :----------------------------: | :---------------------------------------------: |
 | ![](./recipes/img/pdf_ner.png) | ![](./recipes/img/speech_to_text_interface.png) |
 
-## What is Kili Playground ?
+## What is Kili Playground?
 
 Kili Playground is a Python client wrapping the GraphQL API of Kili Technology.
 It allows data scientists and developers to control Kili Technology from an IDE.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,23 @@ pip install kili
 
 ![](./recipes/img/api_key.gif)
 
-- In your favourite IDE :
+- Add the `KILI_API_KEY` variable in your bash environment (or in the settings of your favorite IDE):
+```bash
+export KILI_API_KEY='MY API KEY'
+```
 
+
+- Then instantiate the Kili client:
 ```python
 from kili.client import Kili
-kili = Kili(api_key='MY API KEY')
-# You can now play with the playground
+kili = Kili()
+# You can now use the Kili client!
 ```
+Note that you can also pass the API key as an argument of the `Kili` initialization:
+```python
+kili = Kili(api_key='MY API KEY')
+```
+
 
 You can follow those tutorials to get started :
 


### PR DESCRIPTION
- [ ] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests.
- [ ] I opened a pull request on the Node playground if the changes are breaking.

This PR updates the instructions to instantiate the Kili client, by adding the case when the API_KEY is passed through the environment. This capability is already present in the `master` branch: https://github.com/kili-technology/kili-playground/blob/e7430bb8a79cc4932b5f68e671598ae9dc81b274/kili/client.py#L56

