### PR TITLE
chore(lab-1215): Add a cd when a kili playground release as been rele…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Release
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools twine wheel
+
+      - name: Build
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+          python -m twine upload dist/*


### PR DESCRIPTION
…ased

- [ ] I opened a merge request on `kili` on a branch with the same name as the branch of the current pull request and forced security tests.
- [ ] I opened a pull request on the Node playground if the changes are breaking.


`PYPI_USERNAME` and `PYPI_PASSWORD` need to be set as secrets