### PR TITLE
feat(ML-27): handle paginated queries inside .assets method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install jupyter nbconvert nbformat pytest
+          pip install jupyter nbconvert nbformat pytest mock pytest-mock
 
       - name: Run all tests and tested notebooks
         run: pytest -s

--- a/kili/utils.py
+++ b/kili/utils.py
@@ -1,0 +1,69 @@
+"""
+Utils
+"""
+from typing import List, Callable
+
+from tqdm import tqdm
+
+# pylint: disable=too-many-arguments,too-many-locals
+def row_generator_from_paginated_calls(
+        skip: int,
+        first: int,
+        count_method: Callable[..., int],
+        count_kwargs: dict,
+        paged_call_method: Callable[..., List[dict]],
+        paged_call_payload: dict,
+        fields: List[str],
+        disable_tqdm: bool):
+    """
+    Builds a row generator from paginated calls.
+
+    Parameters
+    ----------
+    - skip : int
+        Number of assets to skip (they are ordered by their date of creation, first to last).
+    - first : int
+        Maximum number of assets to return.
+    - count_method: ... -> int
+        Callable returning the number of available assets given `count_args`.
+    - count_kwargs: dict
+        Keyword arguments passed to the `count_method`.
+    - paged_call_method: ... -> List[dict]
+        Callable returning the list of samples.
+    - paged_call_payload: dict
+        Payload for the GraphQL query.
+    - fields: List[str]
+        The list of strings to retrieved.
+    - disable_tqdm: bool
+        If `True`, disables tqdm.
+    """
+    count_rows_retrieved = 0
+    count_rows_available = count_method(**count_kwargs)
+    if not disable_tqdm:
+        count_rows_queried_total = min(count_rows_available,
+                first) if first is not None else count_rows_available
+        if count_rows_queried_total == 0:
+            yield from ()
+    else:
+        # dummy value that won't have any impact since tqdm is disabled
+        count_rows_queried_total = 1
+    count_rows_query_default = min(100, first or 100)
+
+    with tqdm(total=count_rows_queried_total, disable=disable_tqdm) as pbar:
+        while True:
+            rows = paged_call_method(
+                count_rows_retrieved + skip,
+                count_rows_query_default,
+                paged_call_payload,
+                fields)
+
+            if rows is None or len(rows) == 0:
+                break
+
+            for row in rows:
+                yield row
+
+            count_rows_retrieved += len(rows)
+            if first is not None and count_rows_retrieved >= first:
+                break
+            pbar.update(count_rows_retrieved)

--- a/test/queries/test_asset.py
+++ b/test/queries/test_asset.py
@@ -1,0 +1,97 @@
+"""
+    Tests assets query.
+"""
+import os
+from kili.client import Kili
+
+api_key = os.getenv("KILI_USER_API_KEY")
+api_endpoint = os.getenv("KILI_API_ENDPOINT")
+kili = Kili(api_key=api_key, api_endpoint=api_endpoint)
+
+TEST_CASES = [
+    {
+        "case": "AAU, When I query assets with first=50, I get the first 50 assets",
+        "args": {"first": 50, "disable_tqdm": True},
+        "expected_result": [{"id": i} for i in range(50)],
+        "expected_type": "list",
+    },
+    {
+        "case": "AAU, When I query assets with first=200, I get the first 200 assets",
+        "args": {"first": 200, "disable_tqdm": True},
+        "expected_result": [{"id": i} for i in range(200)],
+        "expected_type": "list",
+    },
+    {
+        "case": "AAU, When I query assets with first=50 and skip=20, I skip the 20"
+        " first assets I get the 50 assets following",
+        "args": {"first": 50, "skip": 20, "disable_tqdm": True},
+        "expected_result": [{"id": i} for i in range(20, 70)],
+        "expected_type": "list",
+    },
+    {
+        "case": "AAU, When I query assets with first=50 and skip=20, I skip the 20"
+        "first assets I get the 200 following assets",
+        "args": {"first": 200, "skip": 20, "disable_tqdm": True},
+        "expected_result": [{"id": i} for i in range(20, 220)],
+        "expected_type": "list",
+    },
+    {
+        "case": "AAU, When I query all assets with as_generator=True, I get a generator"
+        " that yields all 1000 assets",
+        "args": {"as_generator": True},
+        "expected_result": [{"id": i} for i in range(1000)],
+        "expected_type": "generator",
+    },
+    {
+        "case": "AAU, When I query assets with first=3, as_generator=True I get a generator"
+        " that yield the 3 assets",
+        "args": {"as_generator": True, "first": 3},
+        "expected_result": [{"id": i} for i in range(3)],
+        "expected_type": "generator",
+    },
+    {
+        "case": "AAU, When I query assets with first=3, skip=20 as_generator=True I get a "
+        "generator that skips the 20 first assets and yield the 3 assets following",
+        "args": {"as_generator": True, "first": 3, "skip": 20},
+        "expected_result": [{"id": i} for i in range(20, 23)],
+        "expected_type": "generator",
+    },
+    {
+        "case": "AAU, When I query assets with first=50 with format=\"pandas\", I get the "
+        "first 50 assets as a pandas DataFrame",
+        "args": {"format": "pandas", "first": 50, "disable_tqdm": True},
+        "expected_result": [{"id": i} for i in range(50)],
+        "expected_type": "DataFrame",
+    },
+]
+
+
+
+
+def test_assets(mocker):
+    """
+        Tests several queries
+    """
+    count_sample_max = 1000
+
+    def mocked_query_assets(skip, count_sample, *_):
+        """
+        Replaces query assets by a list of assets
+        """
+        max_range = min(count_sample_max, skip + count_sample)
+        res = [{"id": i} for i in range(skip, max_range)]
+        return res
+
+    mocker.patch("kili.queries.asset.QueriesAsset._query_assets", side_effect=mocked_query_assets)
+    mocker.patch("kili.queries.asset.QueriesAsset.count_assets", return_value=count_sample_max)
+    for test_case in TEST_CASES:
+        case_name = test_case["case"]
+        expected = test_case["expected_result"]
+        actual = kili.assets(**test_case["args"])
+        assert type(actual).__name__ == test_case["expected_type"], \
+            f"Test case \"{case_name}\" failed"
+        if type(actual).__name__ == "DataFrame":
+            actual_list = actual.to_dict(orient='records')
+        else:
+            actual_list = list(actual)
+        assert expected == actual_list, f"Test case \"{case_name}\" failed"


### PR DESCRIPTION
**Overview**
This PR handles the asset pagination through a generator.  Additionally, when `as_generator` is passed as an argument, it outputs a generator of the asset samples. 
It also fixes the following issue: when the `first` argument was passed, it was not using pagination internally and was calling the API directly with the `first` parameter (making it crash if too high)

**Code changes**
* changed `.assets` method in `kili.queries.asset`
* added a `row_generator_from_paginated_calls` which can be used across the board to paginate the other row types.

**Test**
Added a unit test for the `.assets` method by mocking the calls to the API. Also tested locally by calling the API.

**Side effects**
May break the usage of assets everywhere, low risk since it has been tested.