### PR TITLE
AAKD, on playground, when I kili.create_predictions with no prediction (empty list), I see an explicit warning message

### DIFF
--- a/kili/mutations/label/__init__.py
+++ b/kili/mutations/label/__init__.py
@@ -4,6 +4,7 @@ Label mutations
 
 from json import dumps
 from typing import List, Optional
+import warnings
 
 from typeguard import typechecked
 
@@ -85,6 +86,9 @@ class MutationsLabel:
             json_response_array), "IDs list and predictions list should have the same length"
         assert len(external_id_array) == len(
             model_name_array), "IDs list and model names list should have the same length"
+        if len(external_id_array) == 0:
+            warnings.warn("Empty IDs and prediction list")
+
         variables = {
             'data': {'modelNameArray': model_name_array,
                      'jsonResponseArray': [dumps(elem) for elem in json_response_array]},


### PR DESCRIPTION
- [ ] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests.
- [ ] I opened a pull request on the Node playground if the changes are breaking.
