### PR TITLE
AAU, on playground, when I query objects, they are returned as a list by default and I don't see warnings anymore

### DIFF
--- a/kili/queries/asset/__init__.py
+++ b/kili/queries/asset/__init__.py
@@ -173,11 +173,6 @@ class QueriesAsset:
             raise ValueError(
                 "Argument values as_generator==True and format==\"pandas\" are not compatible.")
 
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
-
         saved_args = locals()
         count_args = {k: v for (k, v) in saved_args.items()
                       if k not in ['skip', 'first', 'disable_tqdm', 'format', 'fields', 'self', 'as_generator']}

--- a/kili/queries/issue/__init__.py
+++ b/kili/queries/issue/__init__.py
@@ -79,10 +79,6 @@ class QueriesIssue:
         >>> kili.issues(project_id=project_id, fields=['author.email'])
         ```
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         count_args = {'project_id': project_id}
         disable_tqdm = disable_tqdm or as_generator

--- a/kili/queries/label/__init__.py
+++ b/kili/queries/label/__init__.py
@@ -128,10 +128,6 @@ class QueriesLabel:
         >>> kili.labels(project_id=project_id, fields=['jsonResponse', 'labelOf.externalId']) # returns a list of all labels of a project and their assets external ID
         >>> kili.labels(project_id=project_id, fields=['jsonResponse'], as_generator=True) # returns a generator of all labels of a project
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         saved_args = locals()
         count_args = {

--- a/kili/queries/lock/__init__.py
+++ b/kili/queries/lock/__init__.py
@@ -64,10 +64,6 @@ class QueriesLock:
         dict
             a result object which contains the query if it was successful, or an error message else.
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         count_args = {}
         payload_query = {

--- a/kili/queries/notification/__init__.py
+++ b/kili/queries/notification/__init__.py
@@ -72,10 +72,6 @@ class QueriesNotification:
         -------
         a result object which contains the query if it was successful, or an error message else.
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         count_args = {"has_been_seen": has_been_seen, "user_id": user_id}
         disable_tqdm = disable_tqdm or as_generator or notification_id is not None

--- a/kili/queries/organization/__init__.py
+++ b/kili/queries/organization/__init__.py
@@ -78,10 +78,6 @@ class QueriesOrganization:
         >>> kili.organizations(organization_id=organization_id, fields=['users.email'])
         [{'users': [{'email': 'john@doe.com'}]}]
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         count_args = {"email": email, "organization_id": organization_id}
         disable_tqdm = disable_tqdm or as_generator

--- a/kili/queries/project/__init__.py
+++ b/kili/queries/project/__init__.py
@@ -96,11 +96,6 @@ class QueriesProject:
         >>> kili.projects()
         """
 
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
-
         saved_args = locals()
         count_args = {
             k: v

--- a/kili/queries/project_user/__init__.py
+++ b/kili/queries/project_user/__init__.py
@@ -81,10 +81,6 @@ class QueriesProjectUser:
         >>> kili.project_users(project_id=project_id, fields=['consensusMark', 'user.email'])
         ```
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         count_args = {"email": email,
                       "id": id,

--- a/kili/queries/project_version/__init__.py
+++ b/kili/queries/project_version/__init__.py
@@ -73,10 +73,6 @@ class QueriesProjectVersion:
         result:
             a result object which contains the query if it was successful, or an error message else.
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         count_args = {"project_id": project_id}
         disable_tqdm = disable_tqdm or as_generator

--- a/kili/queries/user/__init__.py
+++ b/kili/queries/user/__init__.py
@@ -80,10 +80,6 @@ class QueriesUser:
         >>> kili.users(organization_id=organization_id)
         ```
         """
-        if as_generator is False:
-            warnings.warn("From 2022-05-18, the default return type will be a generator. Currently, the default return type is a list. \n"
-                          "If you want to force the query return to be a list, you can already call this method with the argument as_generator=False",
-                          DeprecationWarning)
 
         count_args = {"organization_id": organization_id}
         disable_tqdm = disable_tqdm or as_generator or (


### PR DESCRIPTION
- [ ] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests.
- [ ] I opened a pull request on the Node playground if the changes are breaking.
