### PR TITLE
feat(LAB-3674): add stepName to appendManyLabels

### DIFF
--- a/src/kili/adapters/kili_api_gateway/label/operations_mixin.py
+++ b/src/kili/adapters/kili_api_gateway/label/operations_mixin.py
@@ -145,6 +145,7 @@ class LabelOperationMixin(BaseOperationMixin):
                 variables = {
                     "data": {
                         "labelType": data.label_type,
+                        "stepName": data.step_name,
                         "overwrite": data.overwrite,
                         "labelsData": [
                             append_label_data_mapper(label) for label in batch_of_label_data

--- a/src/kili/adapters/kili_api_gateway/label/types.py
+++ b/src/kili/adapters/kili_api_gateway/label/types.py
@@ -37,6 +37,7 @@ class AppendManyLabelsData:
     labels_data: List[AppendLabelData]
     label_type: LabelType
     overwrite: Optional[bool]
+    step_name: Optional[str] = None
 
 
 @dataclass

--- a/src/kili/presentation/client/label.py
+++ b/src/kili/presentation/client/label.py
@@ -881,6 +881,7 @@ class LabelClientMethods(BaseClientMethods):
         asset_external_id_array: Optional[List[str]] = None,
         disable_tqdm: Optional[bool] = None,
         overwrite: bool = False,
+        step_name: Optional[str] = None,
     ) -> List[Dict[Literal["id"], str]]:
         """Append labels to assets.
 
@@ -898,6 +899,8 @@ class LabelClientMethods(BaseClientMethods):
             overwrite: when uploading prediction or inference labels, if True,
                 it will overwrite existing labels with the same model name
                 and of the same label type, on the targeted assets.
+            step_name: Name of the step to which the labels belong.
+                The label_type must match accordingly.
 
         Returns:
             A list of dictionaries with the label ids.
@@ -956,6 +959,7 @@ class LabelClientMethods(BaseClientMethods):
             fields=("id",),
             disable_tqdm=disable_tqdm,
             label_type=label_type,
+            step_name=step_name,
             labels=labels,
             overwrite=overwrite,
             project_id=ProjectId(project_id) if project_id else None,

--- a/src/kili/use_cases/label/__init__.py
+++ b/src/kili/use_cases/label/__init__.py
@@ -82,6 +82,7 @@ class LabelUseCases(BaseUseCases):
         project_id: Optional[ProjectId],
         fields: ListOrTuple[str],
         disable_tqdm: Optional[bool],
+        step_name: Optional[str] = None,
     ) -> List[Dict]:
         """Append labels."""
         check_input_labels(labels)
@@ -111,6 +112,7 @@ class LabelUseCases(BaseUseCases):
 
         data = AppendManyLabelsData(
             label_type=label_type,
+            step_name=step_name,
             overwrite=overwrite,
             labels_data=labels_to_add,
         )


### PR DESCRIPTION
This MR is for ticket : 
https://linear.app/kili-technology/issue/LAB-3674/wv2-aau-i-can-correct-my-labels-addtoreview-using-the-sdk

It gives the opportunity to provide a stepName when pushing a label with append_labels.
When given, it will provide this parameter to the backend call : 
- this parameter will allow the label to be considered to correct a label or to push a label on the next step if applicable in both cases