### PR TITLE
feat(LAB-4291): add copy_workflow_from_project SDK method

### DIFF
--- a/recipes/copy_workflow_between_projects.ipynb
+++ b/recipes/copy_workflow_between_projects.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/kili-technology/kili-python-sdk/blob/main/recipes/copy_workflow_between_projects.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to copy a workflow between projects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this recipe, we will learn how to replicate a multi-step workflow from one project to another using `copy_workflow_from_project`.\n",
+    "\n",
+    "This is useful when you want to:\n",
+    "- Bootstrap a new project with the workflow configuration as an existing one\n",
+    "- Standardize workflow settings across several projects\n",
+    "\n",
+    "The copy operation:\n",
+    "1. Reads all workflow steps from the **source** project (step type, consensus coverage, step coverage, send-back links…)\n",
+    "2. Replaces the steps in the **destination** project with a matching structure\n",
+    "3. Assigns all activated destination-project members to each new step (labelers for DEFAULT steps, non-labelers for REVIEW steps)\n",
+    "4. Remaps any `sendBackStepId` references to the newly created destination-step IDs\n",
+    "\n",
+    "> **Requirements**\n",
+    "> - Both projects must use **workflow V2**.\n",
+    "> - The destination project must have **no labels** at the time of copying.\n",
+    "> - If the first source step has a consensus setting, the destination project must have activated members."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install kili"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kili.client import Kili\n",
+    "\n",
+    "kili = Kili(\n",
+    "    # api_endpoint=\"https://cloud.kili-technology.com/api/label/v2/graphql\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the source project and its workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by creating a source project and configuring a two-step workflow:\n",
+    "- A **Labeling** step (DEFAULT) with 50 % consensus coverage and 2 required labelers\n",
+    "- A **Review** step covering 80 % of assets, that can send assets back to Labeling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source project: cmn8z1aoz004rme4i4zx8c81w\n"
+     ]
+    }
+   ],
+   "source": [
+    "json_interface = {\n",
+    "    \"jobs\": {\n",
+    "        \"JOB_0\": {\n",
+    "            \"mlTask\": \"CLASSIFICATION\",\n",
+    "            \"required\": 0,\n",
+    "            \"isChild\": False,\n",
+    "            \"content\": {\n",
+    "                \"categories\": {\n",
+    "                    \"CATEGORY_A\": {\"name\": \"Category A\", \"children\": []},\n",
+    "                    \"CATEGORY_B\": {\"name\": \"Category B\", \"children\": []},\n",
+    "                },\n",
+    "                \"input\": \"radio\",\n",
+    "            },\n",
+    "            \"isNew\": False,\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "source_project_id = kili.create_project(\n",
+    "    input_type=\"IMAGE\",\n",
+    "    json_interface=json_interface,\n",
+    "    title=\"[Kili SDK Notebook]: copy workflow — source\",\n",
+    ")[\"id\"]\n",
+    "print(\"Source project:\", source_project_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add members to the source project so that steps have assignees:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Replace with real email addresses that exist in your organisation\n",
+    "source_labeler_emails = [\"labeler1@example.com\", \"labeler2@example.com\"]\n",
+    "source_reviewer_emails = [\"reviewer1@example.com\"]\n",
+    "\n",
+    "for email in source_labeler_emails:\n",
+    "    kili.append_to_roles(project_id=source_project_id, user_email=email, role=\"LABELER\")\n",
+    "\n",
+    "for email in source_reviewer_emails:\n",
+    "    kili.append_to_roles(project_id=source_project_id, user_email=email, role=\"REVIEWER\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Retrieve the member IDs needed to assign steps, then create the workflow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source workflow steps:\n",
+      " - {'assignees': [{'email': 'test+edouard@kili-technology.com', 'id': 'user-2'}, {'email': 'labeler1@example.com', 'id': 'cmn8yvbve000lme4i2yxa252z'}, {'email': 'labeler2@example.com', 'id': 'cmn8yvbzi000tme4ifga589w7'}, {'email': 'reviewer1@example.com', 'id': 'cmn8yvc2h0011me4iajuh8v1r'}], 'type': 'DEFAULT', 'name': 'Labeling Renamed', 'id': 'cmn8z1apd004tme4i9bvbfwrv'}\n",
+      " - {'assignees': [{'email': 'test+edouard@kili-technology.com', 'id': 'user-2'}, {'email': 'reviewer1@example.com', 'id': 'cmn8yvc2h0011me4iajuh8v1r'}], 'type': 'REVIEW', 'name': 'Review', 'id': 'cmn8z1apn004ume4i8hwm0kce'}\n",
+      " - {'assignees': [{'email': 'test+edouard@kili-technology.com', 'id': 'user-2'}, {'email': 'test+max@kili-technology.com', 'id': 'user-7'}, {'email': 'test+queues@kili-technology.com', 'id': 'user-9'}, {'email': 'test+github@kili-technology.com', 'id': 'user-6'}, {'email': 'reviewer1@example.com', 'id': 'cmn8yvc2h0011me4iajuh8v1r'}], 'type': 'REVIEW', 'name': 'Review 2', 'id': 'cmn8z1e77005tme4ia3r05pk2'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from kili.use_cases.project_workflow import ProjectWorkflowUseCases  # noqa: F401\n",
+    "\n",
+    "# Fetch activated members and split by role\n",
+    "members = kili.project_users(project_id=source_project_id, fields=[\"role\", \"user.id\"])\n",
+    "all_ids = [m[\"user\"][\"id\"] for m in members]\n",
+    "reviewer_ids = [m[\"user\"][\"id\"] for m in members if m[\"role\"] != \"LABELER\"]\n",
+    "\n",
+    "# Get the default (first) step so we can reference its id for sendBackStepId later\n",
+    "initial_steps = kili.get_steps(project_id=source_project_id)\n",
+    "first_step_id = initial_steps[0][\"id\"] if initial_steps else None\n",
+    "\n",
+    "# Build a two-step workflow\n",
+    "kili.update_project_workflow(\n",
+    "    project_id=source_project_id,\n",
+    "    enforce_step_separation=True,\n",
+    "    update_steps=[\n",
+    "        {\n",
+    "            \"id\": first_step_id,\n",
+    "            \"name\": \"Labeling Renamed\",\n",
+    "            \"consensus_coverage\": 50,\n",
+    "            \"number_of_expected_labels_for_consensus\": 2,\n",
+    "        }\n",
+    "    ]\n",
+    "    if first_step_id\n",
+    "    else None,\n",
+    "    create_steps=[\n",
+    "        {\n",
+    "            \"name\": \"Review 2\",\n",
+    "            \"type\": \"REVIEW\",\n",
+    "            \"step_coverage\": 80,\n",
+    "            \"assignees\": reviewer_ids,\n",
+    "            \"send_back_step_id\": first_step_id,\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "# Confirm the source workflow\n",
+    "source_steps = kili.get_steps(project_id=source_project_id)\n",
+    "print(\"Source workflow steps:\")\n",
+    "for step in source_steps:\n",
+    "    print(\" -\", step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the destination project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Destination project: cmn8z1hbg005yme4i3e6sc8mv\n"
+     ]
+    }
+   ],
+   "source": [
+    "destination_project_id = kili.create_project(\n",
+    "    input_type=\"IMAGE\",\n",
+    "    json_interface=json_interface,\n",
+    "    title=\"[Kili SDK Notebook]: copy workflow — destination\",\n",
+    ")[\"id\"]\n",
+    "print(\"Destination project:\", destination_project_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add at least as many labelers to the destination project as required by the source workflow's consensus setting (2 in our case):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Replace with real email addresses that exist in your organisation\n",
+    "dest_labeler_emails = [\"dest_labeler1@example.com\", \"dest_labeler2@example.com\"]\n",
+    "dest_reviewer_emails = [\"dest_reviewer1@example.com\"]\n",
+    "\n",
+    "for email in dest_labeler_emails:\n",
+    "    kili.append_to_roles(project_id=destination_project_id, user_email=email, role=\"LABELER\")\n",
+    "\n",
+    "for email in dest_reviewer_emails:\n",
+    "    kili.append_to_roles(project_id=destination_project_id, user_email=email, role=\"REVIEWER\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Copy the workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A single call copies the full workflow configuration from the source to the destination project:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'enforceStepSeparation': True, 'steps': [{'id': 'cmn8z1hbw0060me4iek7parym'}, {'id': 'cmn8z1kio0070me4i7nrta6fc'}, {'id': 'cmn8z1kiu0071me4ie9kg0tn9'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = kili.copy_workflow_from_project(\n",
+    "    destination_project_id=destination_project_id,\n",
+    "    source_project_id=source_project_id,\n",
+    ")\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Verify the copied workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The destination project should now have the same step structure as the source:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Destination workflow steps after copy:\n",
+      " - {'name': 'Labeling Renamed', 'type': 'DEFAULT', 'consensusCoverage': 50, 'numberOfExpectedLabelsForConsensus': 2, 'stepCoverage': None, 'sendBackStepId': None}\n",
+      " - {'name': 'Review', 'type': 'REVIEW', 'consensusCoverage': None, 'numberOfExpectedLabelsForConsensus': None, 'stepCoverage': None, 'sendBackStepId': None}\n",
+      " - {'name': 'Review 2', 'type': 'REVIEW', 'consensusCoverage': None, 'numberOfExpectedLabelsForConsensus': None, 'stepCoverage': 80, 'sendBackStepId': 'cmn8z1hbw0060me4iek7parym'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "dest_steps = kili.get_steps(\n",
+    "    project_id=destination_project_id,\n",
+    "    fields=[\n",
+    "        \"steps.name\",\n",
+    "        \"steps.type\",\n",
+    "        \"steps.consensusCoverage\",\n",
+    "        \"steps.numberOfExpectedLabelsForConsensus\",\n",
+    "        \"steps.stepCoverage\",\n",
+    "        \"steps.sendBackStepId\",\n",
+    "    ],\n",
+    ")\n",
+    "print(\"Destination workflow steps after copy:\")\n",
+    "for step in dest_steps:\n",
+    "    print(\" -\", step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You should see:\n",
+    "- A **Labeling** (DEFAULT) step with `consensusCoverage=50` and `numberOfExpectedLabelsForConsensus=2`\n",
+    "- A **Review** step with `stepCoverage=80` and a `sendBackStepId` pointing to the new Labeling step ID\n",
+    "\n",
+    "The assignees on each step are the destination-project members, not the source-project members."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'cmn8z0wln0044me4icsblhtja'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kili.delete_project(source_project_id)\n",
+    "kili.delete_project(destination_project_id)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/kili/adapters/kili_api_gateway/project_workflow/mappers.py
+++ b/src/kili/adapters/kili_api_gateway/project_workflow/mappers.py
@@ -1,7 +1,5 @@
 """GraphQL payload data mappers for project operations."""
 
-from typing import Union
-
 from kili.domain.project import WorkflowStepCreate, WorkflowStepUpdate
 
 from .types import ProjectWorkflowDataKiliAPIGatewayInput
@@ -12,10 +10,14 @@ def project_input_mapper(data: ProjectWorkflowDataKiliAPIGatewayInput) -> dict:
     return {
         "enforceStepSeparation": data.enforce_step_separation,
         "steps": {
-            "creates": [update_step_mapper(step) for step in data.create_steps]
+            "creates": [
+                update_step_mapper(step, for_copy=data.for_copy) for step in data.create_steps
+            ]
             if data.create_steps
             else [],
-            "updates": [update_step_mapper(step) for step in data.update_steps]
+            "updates": [
+                update_step_mapper(step, for_copy=data.for_copy) for step in data.update_steps
+            ]
             if data.update_steps
             else [],
             "deletes": data.delete_steps if data.delete_steps else [],
@@ -23,18 +25,24 @@ def project_input_mapper(data: ProjectWorkflowDataKiliAPIGatewayInput) -> dict:
     }
 
 
-def update_step_mapper(data: Union[WorkflowStepCreate, WorkflowStepUpdate]) -> dict:
+def update_step_mapper(
+    data: WorkflowStepCreate | WorkflowStepUpdate, for_copy: bool = False
+) -> dict:
     """Build the GraphQL create StepData variable to be sent in an operation."""
+    ## In copy worklow use case, we want to copy as well
+    # consensusCoverage and numberOfExpectedLabelsForConsensus properties, even if they are None
+
     step = {
-        "id": data["id"] if "id" in data else None,
-        "name": data["name"] if "name" in data else None,
-        "consensusCoverage": data["consensus_coverage"] if "consensus_coverage" in data else None,
-        "numberOfExpectedLabelsForConsensus": data["number_of_expected_labels_for_consensus"]
-        if "number_of_expected_labels_for_consensus" in data
-        else None,
-        "stepCoverage": data["step_coverage"] if "step_coverage" in data else None,
-        "type": data["type"] if "type" in data else None,
-        "assignees": data["assignees"] if "assignees" in data else None,
-        "sendBackStepId": data["send_back_step_id"] if "send_back_step_id" in data else None,
+        "id": data.get("id"),
+        "name": data.get("name"),
+        "consensusCoverage": data.get("consensus_coverage"),
+        "numberOfExpectedLabelsForConsensus": data.get("number_of_expected_labels_for_consensus"),
+        "stepCoverage": data.get("step_coverage"),
+        "type": data.get("type"),
+        "assignees": data.get("assignees"),
+        "sendBackStepId": data.get("send_back_step_id"),
     }
+    if for_copy:
+        special_keys = ["consensusCoverage", "numberOfExpectedLabelsForConsensus"]
+        return {k: v for k, v in step.items() if v is not None or k in special_keys}
     return {k: v for k, v in step.items() if v is not None}

--- a/src/kili/adapters/kili_api_gateway/project_workflow/mappers.py
+++ b/src/kili/adapters/kili_api_gateway/project_workflow/mappers.py
@@ -35,5 +35,6 @@ def update_step_mapper(data: Union[WorkflowStepCreate, WorkflowStepUpdate]) -> d
         "stepCoverage": data["step_coverage"] if "step_coverage" in data else None,
         "type": data["type"] if "type" in data else None,
         "assignees": data["assignees"] if "assignees" in data else None,
+        "sendBackStepId": data["send_back_step_id"] if "send_back_step_id" in data else None,
     }
     return {k: v for k, v in step.items() if v is not None}

--- a/src/kili/adapters/kili_api_gateway/project_workflow/operations_mixin.py
+++ b/src/kili/adapters/kili_api_gateway/project_workflow/operations_mixin.py
@@ -60,6 +60,22 @@ class ProjectWorkflowOperationMixin(BaseOperationMixin):
 
         return steps
 
+    def count_activated_project_users(self, project_id: str) -> int:
+        """Count project users with ACTIVATED status."""
+        where = ProjectUserWhere(project_id=project_id, status="ACTIVATED")
+        return ProjectUserQuery(self.graphql_client, self.http_client).count(where)
+
+    def list_activated_project_users(self, project_id: str) -> list[dict]:
+        """List project users with ACTIVATED status, returning role and user id."""
+        where = ProjectUserWhere(project_id=project_id, status="ACTIVATED")
+        return list(
+            ProjectUserQuery(self.graphql_client, self.http_client)(
+                where=where,
+                fields=["role", "user.id"],
+                options=QueryOptions(disable_tqdm=True),
+            )
+        )
+
     def add_reviewers_to_step(
         self, project_id: str, step_name: str, emails: list[str]
     ) -> list[str]:

--- a/src/kili/adapters/kili_api_gateway/project_workflow/types.py
+++ b/src/kili/adapters/kili_api_gateway/project_workflow/types.py
@@ -14,3 +14,4 @@ class ProjectWorkflowDataKiliAPIGatewayInput:
     create_steps: Optional[list[WorkflowStepCreate]]
     update_steps: Optional[list[WorkflowStepUpdate]]
     delete_steps: Optional[list[str]]
+    for_copy: bool = False

--- a/src/kili/domain/project.py
+++ b/src/kili/domain/project.py
@@ -35,6 +35,7 @@ class WorkflowStepCreate(TypedDict, total=False):
     step_coverage: Optional[int]
     type: Required[Literal["DEFAULT", "REVIEW"]]
     assignees: Required[list[str]]
+    send_back_step_id: Optional[str]
 
 
 class WorkflowStepUpdate(TypedDict, total=False):
@@ -47,6 +48,7 @@ class WorkflowStepUpdate(TypedDict, total=False):
     step_coverage: Optional[int]
     type: Optional[Literal["DEFAULT", "REVIEW"]]
     assignees: Optional[list[str]]
+    send_back_step_id: Optional[str]
 
 
 class InputTypeEnum(str, Enum):

--- a/src/kili/domain_api/projects.py
+++ b/src/kili/domain_api/projects.py
@@ -321,6 +321,43 @@ class WorkflowNamespace:
             project_id=project_id, step_name=step_name, emails=emails
         )
 
+    @typechecked
+    def copy_from_project(
+        self,
+        destination_project_id: str,
+        source_project_id: str,
+    ) -> dict[str, Any]:
+        """Copy the workflow from a source project to a destination project.
+
+        Copies all workflow steps with their configurations (consensus, coverage,
+        sendBackStepId) from the source project. Assignees are not copied.
+
+        The destination project must have no labels. Existing workflow steps in the
+        destination project will be deleted and replaced by the source workflow.
+
+        Args:
+            destination_project_id: Id of the destination project to copy the workflow to.
+            source_project_id: Id of the source project to copy the workflow from.
+
+        Returns:
+            A dict with the workflow data which indicates if the mutation was successful,
+                else an error message.
+
+        Raises:
+            ValueError: If the source project has no workflow steps, or if the
+                destination project already has labels.
+
+        Examples:
+            >>> kili.projects.workflow.copy_from_project(
+            ...     destination_project_id="destination_project_id",
+            ...     source_project_id="source_project_id",
+            ... )
+        """
+        return self._client.copy_workflow_from_project(
+            destination_project_id=destination_project_id,
+            source_project_id=source_project_id,
+        )
+
 
 class ProjectsNamespace(DomainNamespace):
     """Projects domain namespace providing project-related operations.

--- a/src/kili/presentation/client/project_workflow.py
+++ b/src/kili/presentation/client/project_workflow.py
@@ -107,3 +107,40 @@ class ProjectWorkflowClientMethods(BaseClientMethods):
         return ProjectWorkflowUseCases(self.kili_api_gateway).remove_reviewers_from_step(
             project_id=project_id, step_name=step_name, emails=emails
         )
+
+    @typechecked
+    def copy_workflow_from_project(
+        self,
+        destination_project_id: str,
+        source_project_id: str,
+    ) -> dict[str, Any]:
+        """Copy the workflow from a source project to a destination project.
+
+        Copies all workflow steps with their configurations (consensus, coverage,
+        sendBackStepId) from the source project. Assignees are not copied.
+
+        The destination project must have no labels. Existing workflow steps in the
+        destination project will be deleted and replaced by the source workflow.
+
+        Args:
+            destination_project_id: Id of the destination project to copy the workflow to.
+            source_project_id: Id of the source project to copy the workflow from.
+
+        Returns:
+            A dict with the workflow data which indicates if the mutation was successful,
+                else an error message.
+
+        Raises:
+            ValueError: If the source project has no workflow steps, or if the
+                destination project already has labels.
+
+        Examples:
+            >>> kili.copy_workflow_from_project(
+            ...     destination_project_id="destination_project_id",
+            ...     source_project_id="source_project_id",
+            ... )
+        """
+        return ProjectWorkflowUseCases(self.kili_api_gateway).copy_workflow_from_project(
+            source_project_id=ProjectId(source_project_id),
+            destination_project_id=ProjectId(destination_project_id),
+        )

--- a/src/kili/use_cases/project_workflow/__init__.py
+++ b/src/kili/use_cases/project_workflow/__init__.py
@@ -76,12 +76,25 @@ class ProjectWorkflowUseCases(BaseUseCases):
         deletes existing destination steps, and creates new steps with remapped sendBackStepId
         references.
         """
+        if source_project_id == destination_project_id:
+            raise ValueError(
+                "Source and destination project IDs must be different."
+                f" Got the same ID: {source_project_id}"
+            )
+
         # 1. Fetch source workflow steps
         logger.info("Fetching workflow steps from source project %s", source_project_id)
         source_steps = self._kili_api_gateway.get_steps(source_project_id, _SOURCE_STEP_FIELDS)
 
         if not source_steps:
             raise ValueError(f"Source project {source_project_id} has no workflow steps to copy.")
+
+        step_names = [step["name"] for step in source_steps]
+        if len(step_names) != len(set(step_names)):
+            raise ValueError(
+                f"Source project {source_project_id} has duplicate step names."
+                " Cannot reliably copy workflow with duplicate step names."
+            )
 
         # 2. Validate destination has no labels
         self._validate_destination_has_no_labels(destination_project_id)
@@ -112,9 +125,11 @@ class ProjectWorkflowUseCases(BaseUseCases):
 
         # 6. Remap sendBackStepId references if any steps had them
         if source_steps_with_send_back:
-            result = self._remap_send_back_step_ids(
+            remap_result = self._remap_send_back_step_ids(
                 source_steps, source_steps_with_send_back, destination_project_id
             )
+            if remap_result:
+                result = remap_result
 
         logger.info(
             "Successfully copied workflow from project %s to project %s",
@@ -149,7 +164,12 @@ class ProjectWorkflowUseCases(BaseUseCases):
             dest_steps = self._kili_api_gateway.get_steps(
                 destination_project_id, ("steps.id", "steps.name")
             )
-        except (ValueError, KeyError):
+        except (ValueError, KeyError) as exc:
+            logger.warning(
+                "Could not fetch existing steps from destination project %s: %s",
+                destination_project_id,
+                exc,
+            )
             dest_steps = []
         return [step["id"] for step in dest_steps]
 

--- a/src/kili/use_cases/project_workflow/__init__.py
+++ b/src/kili/use_cases/project_workflow/__init__.py
@@ -96,19 +96,52 @@ class ProjectWorkflowUseCases(BaseUseCases):
                 " Cannot reliably copy workflow with duplicate step names."
             )
 
-        # 2. Validate destination has no labels
+        # 2. Validate destination project is workflow V2
+        self._validate_destination_is_workflow_v2(destination_project_id)
+
+        # 3. Validate destination has no labels
         self._validate_destination_has_no_labels(destination_project_id)
 
-        # 3. Get existing destination steps to delete
-        dest_step_ids = self._get_destination_step_ids(destination_project_id)
+        # 4. Get existing destination steps
+        dest_steps = self._get_destination_steps(destination_project_id)
 
-        # 4. Build create steps and track sendBackStepId references
-        steps_to_create, source_steps_with_send_back = _build_steps_to_create(source_steps)
+        # 5. Build operations:
+        # - Update the first dest step (cannot delete it) with first source step properties
+        # - Delete remaining dest steps
+        # - Create remaining source steps (index 1+)
+        first_dest_step = dest_steps[0] if dest_steps else None
 
-        # 5. Execute: delete existing + create new steps in a single call
+        update_steps: list[WorkflowStepUpdate] = []
+        steps_to_create: list[WorkflowStepCreate] = []
+        source_steps_with_send_back: list[tuple[str, str]] = []  # (step_name, source_send_back_id)
+
+        if first_dest_step:
+            update_steps = [_build_step_update(str(first_dest_step["id"]), source_steps[0])]
+            if source_steps[0].get("sendBackStepId"):
+                source_steps_with_send_back.append(
+                    (str(source_steps[0]["name"]), str(source_steps[0]["sendBackStepId"]))
+                )
+            for step in source_steps[1:]:
+                steps_to_create.append(_make_create_step(step))
+                if step.get("sendBackStepId"):
+                    source_steps_with_send_back.append(
+                        (str(step["name"]), str(step["sendBackStepId"]))
+                    )
+        else:
+            # No existing dest steps — create all source steps
+            for step in source_steps:
+                steps_to_create.append(_make_create_step(step))
+                if step.get("sendBackStepId"):
+                    source_steps_with_send_back.append(
+                        (str(step["name"]), str(step["sendBackStepId"]))
+                    )
+
+        delete_steps = [str(step["id"]) for step in dest_steps[1:]] or None
+
+        # 5. Execute: update first step + delete old extras + create new steps
         logger.info(
             "Copying %d steps from project %s to project %s",
-            len(steps_to_create),
+            len(source_steps),
             source_project_id,
             destination_project_id,
         )
@@ -117,9 +150,9 @@ class ProjectWorkflowUseCases(BaseUseCases):
             destination_project_id,
             ProjectWorkflowDataKiliAPIGatewayInput(
                 enforce_step_separation=None,
-                create_steps=steps_to_create,
-                update_steps=None,
-                delete_steps=dest_step_ids or None,
+                create_steps=steps_to_create or None,
+                update_steps=update_steps or None,
+                delete_steps=delete_steps,
             ),
         )
 
@@ -138,6 +171,18 @@ class ProjectWorkflowUseCases(BaseUseCases):
         )
         return result
 
+    def _validate_destination_is_workflow_v2(self, destination_project_id: ProjectId) -> None:
+        """Validate that the destination project uses workflow V2."""
+        project = self._kili_api_gateway.get_project(
+            project_id=destination_project_id, fields=["workflowVersion"]
+        )
+        version = project.get("workflowVersion")
+        if version != "V2":
+            raise ValueError(
+                f"Destination project {destination_project_id} uses workflow version"
+                f" '{version}'. Only workflow V2 projects support multi-step workflows."
+            )
+
     def _validate_destination_has_no_labels(self, destination_project_id: ProjectId) -> None:
         """Validate that the destination project has no labels."""
         logger.info(
@@ -154,14 +199,14 @@ class ProjectWorkflowUseCases(BaseUseCases):
                 " that has already been labeled."
             )
 
-    def _get_destination_step_ids(self, destination_project_id: ProjectId) -> list[str]:
-        """Get existing step IDs from the destination project."""
+    def _get_destination_steps(self, destination_project_id: ProjectId) -> list[dict[str, object]]:
+        """Get existing steps from the destination project."""
         logger.info(
             "Fetching existing steps from destination project %s",
             destination_project_id,
         )
         try:
-            dest_steps = self._kili_api_gateway.get_steps(
+            return self._kili_api_gateway.get_steps(
                 destination_project_id, ("steps.id", "steps.name")
             )
         except (ValueError, KeyError) as exc:
@@ -170,100 +215,94 @@ class ProjectWorkflowUseCases(BaseUseCases):
                 destination_project_id,
                 exc,
             )
-            dest_steps = []
-        return [step["id"] for step in dest_steps]
+            return []
 
     def _remap_send_back_step_ids(
         self,
         source_steps: list[dict[str, object]],
-        source_steps_with_send_back: list[tuple[int, str]],
+        source_steps_with_send_back: list[tuple[str, str]],
         destination_project_id: ProjectId,
     ) -> dict[str, object]:
         """Remap sendBackStepId references from source to new destination step IDs."""
         logger.info("Remapping sendBackStepId references for copied steps")
 
-        source_id_to_idx = {step["id"]: idx for idx, step in enumerate(source_steps)}
+        source_id_to_name = {str(step["id"]): str(step["name"]) for step in source_steps}
         new_steps = self._kili_api_gateway.get_steps(
             destination_project_id, ("steps.id", "steps.name")
         )
+        name_to_new_id = {str(step["name"]): str(step["id"]) for step in new_steps}
 
-        name_to_new_id = {step["name"]: step["id"] for step in new_steps}
-        idx_to_name = {idx: step["name"] for idx, step in enumerate(source_steps)}
-
-        updates_for_send_back = _build_send_back_updates(
-            source_steps_with_send_back, source_id_to_idx, idx_to_name, name_to_new_id
+        updates = _build_send_back_updates(
+            source_steps_with_send_back, source_id_to_name, name_to_new_id
         )
 
-        if updates_for_send_back:
+        if updates:
             return self._kili_api_gateway.update_project_workflow(
                 destination_project_id,
                 ProjectWorkflowDataKiliAPIGatewayInput(
                     enforce_step_separation=None,
                     create_steps=None,
-                    update_steps=updates_for_send_back,
+                    update_steps=updates,
                     delete_steps=None,
                 ),
             )
         return {}
 
 
-def _build_steps_to_create(
-    source_steps: list[dict[str, object]],
-) -> tuple[list[WorkflowStepCreate], list[tuple[int, str]]]:
-    """Build WorkflowStepCreate list from source steps and track sendBackStepId references."""
-    steps_to_create: list[WorkflowStepCreate] = []
-    source_steps_with_send_back: list[tuple[int, str]] = []
+def _make_create_step(step: dict[str, object]) -> WorkflowStepCreate:
+    """Build a WorkflowStepCreate from a source step. Assignees are omitted (backend default)."""
+    create_step: WorkflowStepCreate = {
+        "name": step["name"],
+        "type": step["type"],
+    }
+    if step.get("consensusCoverage") is not None:
+        create_step["consensus_coverage"] = step["consensusCoverage"]
+    if step.get("numberOfExpectedLabelsForConsensus") is not None:
+        create_step["number_of_expected_labels_for_consensus"] = step[
+            "numberOfExpectedLabelsForConsensus"
+        ]
+    if step.get("stepCoverage") is not None:
+        create_step["step_coverage"] = step["stepCoverage"]
+    return create_step
 
-    for idx, step in enumerate(source_steps):
-        create_step: WorkflowStepCreate = {
-            "name": step["name"],
-            "type": step["type"],
-            "assignees": [],  # Don't copy assignees per spec
-        }
-        if step.get("consensusCoverage") is not None:
-            create_step["consensus_coverage"] = step["consensusCoverage"]
-        if step.get("numberOfExpectedLabelsForConsensus") is not None:
-            create_step["number_of_expected_labels_for_consensus"] = step[
-                "numberOfExpectedLabelsForConsensus"
-            ]
-        if step.get("stepCoverage") is not None:
-            create_step["step_coverage"] = step["stepCoverage"]
 
-        if step.get("sendBackStepId"):
-            source_steps_with_send_back.append((idx, step["sendBackStepId"]))
-
-        steps_to_create.append(create_step)
-
-    return steps_to_create, source_steps_with_send_back
+def _build_step_update(dest_step_id: str, source_step: dict[str, object]) -> WorkflowStepUpdate:
+    """Build a WorkflowStepUpdate for the first dest step based on source step properties."""
+    update: WorkflowStepUpdate = {
+        "id": dest_step_id,
+        "name": source_step["name"],
+        "type": source_step["type"],
+    }
+    if source_step.get("consensusCoverage") is not None:
+        update["consensus_coverage"] = source_step["consensusCoverage"]
+    if source_step.get("numberOfExpectedLabelsForConsensus") is not None:
+        update["number_of_expected_labels_for_consensus"] = source_step[
+            "numberOfExpectedLabelsForConsensus"
+        ]
+    if source_step.get("stepCoverage") is not None:
+        update["step_coverage"] = source_step["stepCoverage"]
+    return update
 
 
 def _build_send_back_updates(
-    source_steps_with_send_back: list[tuple[int, str]],
-    source_id_to_idx: dict[str, int],
-    idx_to_name: dict[int, str],
+    source_steps_with_send_back: list[tuple[str, str]],
+    source_id_to_name: dict[str, str],
     name_to_new_id: dict[str, str],
 ) -> list[WorkflowStepUpdate]:
     """Build WorkflowStepUpdate list for sendBackStepId remapping."""
     updates: list[WorkflowStepUpdate] = []
-    for step_idx, source_send_back_id in source_steps_with_send_back:
-        target_source_idx = source_id_to_idx.get(source_send_back_id)
-        if target_source_idx is None:
+    for step_name, source_send_back_id in source_steps_with_send_back:
+        target_name = source_id_to_name.get(source_send_back_id)
+        if target_name is None:
             logger.warning(
                 "Could not find source step for sendBackStepId %s, skipping",
                 source_send_back_id,
             )
             continue
 
-        step_name = idx_to_name[step_idx]
-        target_name = idx_to_name[target_source_idx]
         new_step_id = name_to_new_id.get(step_name)
         new_target_id = name_to_new_id.get(target_name)
 
         if new_step_id and new_target_id:
-            updates.append(
-                {
-                    "id": new_step_id,
-                    "send_back_step_id": new_target_id,
-                }
-            )
+            updates.append({"id": new_step_id, "send_back_step_id": new_target_id})
     return updates

--- a/src/kili/use_cases/project_workflow/__init__.py
+++ b/src/kili/use_cases/project_workflow/__init__.py
@@ -21,6 +21,8 @@ _SOURCE_STEP_FIELDS = (
     "steps.numberOfExpectedLabelsForConsensus",
     "steps.stepCoverage",
     "steps.sendBackStepId",
+    "steps.useHoneypot",
+    "steps.allowedJobNames",
 )
 
 
@@ -82,7 +84,7 @@ class ProjectWorkflowUseCases(BaseUseCases):
                 f" Got the same ID: {source_project_id}"
             )
 
-        # 1. Fetch source workflow steps
+        # 1. Fetch source workflow steps and settings
         logger.info("Fetching workflow steps from source project %s", source_project_id)
         source_steps = self._kili_api_gateway.get_steps(source_project_id, _SOURCE_STEP_FIELDS)
 
@@ -96,19 +98,32 @@ class ProjectWorkflowUseCases(BaseUseCases):
                 " Cannot reliably copy workflow with duplicate step names."
             )
 
+        source_project = self._kili_api_gateway.get_project(
+            project_id=source_project_id, fields=["enforceStepSeparation"]
+        )
+        enforce_step_separation: bool | None = source_project.get("enforceStepSeparation")
+
         # 2. Validate destination project is workflow V2
         self._validate_destination_is_workflow_v2(destination_project_id)
 
         # 3. Validate destination has no labels
         self._validate_destination_has_no_labels(destination_project_id)
 
-        # 4. Get existing destination steps
+        # 3b. Validate destination has enough labelers for consensus on the first step
+        self._validate_consensus_labelers(destination_project_id, source_steps[0])
+
+        # 4. Get existing destination steps and activated users
         dest_steps = self._get_destination_steps(destination_project_id)
+        dest_users = self._kili_api_gateway.list_activated_project_users(
+            str(destination_project_id)
+        )
+        labeler_ids = [str(u["user"]["id"]) for u in dest_users]
+        reviewer_ids = [str(u["user"]["id"]) for u in dest_users if u.get("role") != "LABELER"]
 
         # 5. Build operations:
         # - Update the first dest step (cannot delete it) with first source step properties
         # - Delete remaining dest steps
-        # - Create remaining source steps (index 1+)
+        # - Create remaining source steps (index 1+) with destination assignees
         first_dest_step = dest_steps[0] if dest_steps else None
 
         update_steps: list[WorkflowStepUpdate] = []
@@ -122,15 +137,17 @@ class ProjectWorkflowUseCases(BaseUseCases):
                     (str(source_steps[0]["name"]), str(source_steps[0]["sendBackStepId"]))
                 )
             for step in source_steps[1:]:
-                steps_to_create.append(_make_create_step(step))
+                assignees = labeler_ids if step.get("type") == "DEFAULT" else reviewer_ids
+                steps_to_create.append(_make_create_step(step, assignees))
                 if step.get("sendBackStepId"):
                     source_steps_with_send_back.append(
                         (str(step["name"]), str(step["sendBackStepId"]))
                     )
         else:
-            # No existing dest steps — create all source steps
+            # No existing dest steps — create all source steps with destination assignees
             for step in source_steps:
-                steps_to_create.append(_make_create_step(step))
+                assignees = labeler_ids if step.get("type") == "DEFAULT" else reviewer_ids
+                steps_to_create.append(_make_create_step(step, assignees))
                 if step.get("sendBackStepId"):
                     source_steps_with_send_back.append(
                         (str(step["name"]), str(step["sendBackStepId"]))
@@ -149,7 +166,7 @@ class ProjectWorkflowUseCases(BaseUseCases):
         result = self._kili_api_gateway.update_project_workflow(
             destination_project_id,
             ProjectWorkflowDataKiliAPIGatewayInput(
-                enforce_step_separation=None,
+                enforce_step_separation=enforce_step_separation,
                 create_steps=steps_to_create or None,
                 update_steps=update_steps or None,
                 delete_steps=delete_steps,
@@ -170,6 +187,23 @@ class ProjectWorkflowUseCases(BaseUseCases):
             destination_project_id,
         )
         return result
+
+    def _validate_consensus_labelers(
+        self, destination_project_id: ProjectId, first_source_step: dict[str, object]
+    ) -> None:
+        """Validate the destination has enough activated labelers for the source consensus setting."""
+        required = first_source_step.get("numberOfExpectedLabelsForConsensus")
+        if not required:
+            return
+        activated_count = self._kili_api_gateway.count_activated_project_users(
+            str(destination_project_id)
+        )
+        if activated_count < required:
+            raise ValueError(
+                f"Destination project {destination_project_id} has {activated_count} activated"
+                f" labeler(s), but the source workflow requires {required} for consensus."
+                " Add more labelers before copying the workflow."
+            )
 
     def _validate_destination_is_workflow_v2(self, destination_project_id: ProjectId) -> None:
         """Validate that the destination project uses workflow V2."""
@@ -249,11 +283,16 @@ class ProjectWorkflowUseCases(BaseUseCases):
         return {}
 
 
-def _make_create_step(step: dict[str, object]) -> WorkflowStepCreate:
-    """Build a WorkflowStepCreate from a source step. Assignees are omitted (backend default)."""
+def _make_create_step(step: dict[str, object], assignees: list[str]) -> WorkflowStepCreate:
+    """Build a WorkflowStepCreate from a source step with destination project assignees.
+
+    For DEFAULT steps, assignees are all activated project users.
+    For REVIEW steps, assignees are activated project users with role != LABELER.
+    """
     create_step: WorkflowStepCreate = {
         "name": step["name"],
         "type": step["type"],
+        "assignees": assignees,
     }
     if step.get("consensusCoverage") is not None:
         create_step["consensus_coverage"] = step["consensusCoverage"]
@@ -263,6 +302,11 @@ def _make_create_step(step: dict[str, object]) -> WorkflowStepCreate:
         ]
     if step.get("stepCoverage") is not None:
         create_step["step_coverage"] = step["stepCoverage"]
+    if step.get("useHoneypot") is not None:
+        create_step["use_honeypot"] = step["useHoneypot"]
+    if step.get("allowedJobNames") is not None:
+        create_step["allowed_job_names"] = step["allowedJobNames"]
+
     return create_step
 
 
@@ -271,7 +315,6 @@ def _build_step_update(dest_step_id: str, source_step: dict[str, object]) -> Wor
     update: WorkflowStepUpdate = {
         "id": dest_step_id,
         "name": source_step["name"],
-        "type": source_step["type"],
     }
     if source_step.get("consensusCoverage") is not None:
         update["consensus_coverage"] = source_step["consensusCoverage"]
@@ -279,8 +322,11 @@ def _build_step_update(dest_step_id: str, source_step: dict[str, object]) -> Wor
         update["number_of_expected_labels_for_consensus"] = source_step[
             "numberOfExpectedLabelsForConsensus"
         ]
-    if source_step.get("stepCoverage") is not None:
-        update["step_coverage"] = source_step["stepCoverage"]
+    if source_step.get("useHoneypot") is not None:
+        update["use_honeypot"] = source_step["useHoneypot"]
+    if source_step.get("allowedJobNames") is not None:
+        update["allowed_job_names"] = source_step["allowedJobNames"]
+
     return update
 
 

--- a/src/kili/use_cases/project_workflow/__init__.py
+++ b/src/kili/use_cases/project_workflow/__init__.py
@@ -1,7 +1,7 @@
 """Project use cases."""
 
 import logging
-from typing import Optional
+from typing import Literal, Optional, cast
 
 from kili.adapters.kili_api_gateway.project_workflow.types import (
     ProjectWorkflowDataKiliAPIGatewayInput,
@@ -191,7 +191,7 @@ class ProjectWorkflowUseCases(BaseUseCases):
         self, destination_project_id: ProjectId, first_source_step: dict[str, object]
     ) -> None:
         """Validate the destination has enough activated labelers for the source consensus setting."""
-        required = first_source_step.get("numberOfExpectedLabelsForConsensus")
+        required = cast("int", first_source_step.get("numberOfExpectedLabelsForConsensus"))
         if not required:
             return
         activated_count = self._kili_api_gateway.count_activated_project_users(
@@ -289,18 +289,18 @@ def _make_create_step(step: dict[str, object], assignees: list[str]) -> Workflow
     For REVIEW steps, assignees are activated project users with role != LABELER.
     """
     create_step: WorkflowStepCreate = {
-        "name": step["name"],
-        "type": step["type"],
+        "name": cast("str", step["name"]),
+        "type": cast("Literal['DEFAULT', 'REVIEW']", step["type"]),
         "assignees": assignees,
     }
     if step.get("consensusCoverage") is not None:
-        create_step["consensus_coverage"] = step["consensusCoverage"]
+        create_step["consensus_coverage"] = cast("int", step["consensusCoverage"])
     if step.get("numberOfExpectedLabelsForConsensus") is not None:
-        create_step["number_of_expected_labels_for_consensus"] = step[
-            "numberOfExpectedLabelsForConsensus"
-        ]
+        create_step["number_of_expected_labels_for_consensus"] = cast(
+            "int", step["numberOfExpectedLabelsForConsensus"]
+        )
     if step.get("stepCoverage") is not None:
-        create_step["step_coverage"] = step["stepCoverage"]
+        create_step["step_coverage"] = cast("int", step["stepCoverage"])
     return create_step
 
 
@@ -308,14 +308,14 @@ def _build_step_update(dest_step_id: str, source_step: dict[str, object]) -> Wor
     """Build a WorkflowStepUpdate for the first dest step based on source step properties."""
     update: WorkflowStepUpdate = {
         "id": dest_step_id,
-        "name": source_step["name"],
+        "name": cast("str", source_step["name"]),
     }
     if source_step.get("consensusCoverage") is not None:
-        update["consensus_coverage"] = source_step["consensusCoverage"]
+        update["consensus_coverage"] = cast("int", source_step["consensusCoverage"])
     if source_step.get("numberOfExpectedLabelsForConsensus") is not None:
-        update["number_of_expected_labels_for_consensus"] = source_step[
-            "numberOfExpectedLabelsForConsensus"
-        ]
+        update["number_of_expected_labels_for_consensus"] = cast(
+            "int", source_step["numberOfExpectedLabelsForConsensus"]
+        )
     return update
 
 

--- a/src/kili/use_cases/project_workflow/__init__.py
+++ b/src/kili/use_cases/project_workflow/__init__.py
@@ -21,8 +21,6 @@ _SOURCE_STEP_FIELDS = (
     "steps.numberOfExpectedLabelsForConsensus",
     "steps.stepCoverage",
     "steps.sendBackStepId",
-    "steps.useHoneypot",
-    "steps.allowedJobNames",
 )
 
 
@@ -170,6 +168,7 @@ class ProjectWorkflowUseCases(BaseUseCases):
                 create_steps=steps_to_create or None,
                 update_steps=update_steps or None,
                 delete_steps=delete_steps,
+                for_copy=True,
             ),
         )
 
@@ -302,11 +301,6 @@ def _make_create_step(step: dict[str, object], assignees: list[str]) -> Workflow
         ]
     if step.get("stepCoverage") is not None:
         create_step["step_coverage"] = step["stepCoverage"]
-    if step.get("useHoneypot") is not None:
-        create_step["use_honeypot"] = step["useHoneypot"]
-    if step.get("allowedJobNames") is not None:
-        create_step["allowed_job_names"] = step["allowedJobNames"]
-
     return create_step
 
 
@@ -322,11 +316,6 @@ def _build_step_update(dest_step_id: str, source_step: dict[str, object]) -> Wor
         update["number_of_expected_labels_for_consensus"] = source_step[
             "numberOfExpectedLabelsForConsensus"
         ]
-    if source_step.get("useHoneypot") is not None:
-        update["use_honeypot"] = source_step["useHoneypot"]
-    if source_step.get("allowedJobNames") is not None:
-        update["allowed_job_names"] = source_step["allowedJobNames"]
-
     return update
 
 

--- a/src/kili/use_cases/project_workflow/__init__.py
+++ b/src/kili/use_cases/project_workflow/__init__.py
@@ -1,13 +1,27 @@
 """Project use cases."""
 
+import logging
 from typing import Optional
 
 from kili.adapters.kili_api_gateway.project_workflow.types import (
     ProjectWorkflowDataKiliAPIGatewayInput,
 )
+from kili.domain.label import LabelFilters
 from kili.domain.project import ProjectId, WorkflowStepCreate, WorkflowStepUpdate
 from kili.domain.types import ListOrTuple
 from kili.use_cases.base import BaseUseCases
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_STEP_FIELDS = (
+    "steps.id",
+    "steps.name",
+    "steps.type",
+    "steps.consensusCoverage",
+    "steps.numberOfExpectedLabelsForConsensus",
+    "steps.stepCoverage",
+    "steps.sendBackStepId",
+)
 
 
 class ProjectWorkflowUseCases(BaseUseCases):
@@ -50,3 +64,186 @@ class ProjectWorkflowUseCases(BaseUseCases):
     ) -> list[str]:
         """Remove reviewers from a specific step."""
         return self._kili_api_gateway.remove_reviewers_from_step(project_id, step_name, emails)
+
+    def copy_workflow_from_project(
+        self,
+        source_project_id: ProjectId,
+        destination_project_id: ProjectId,
+    ) -> dict[str, object]:
+        """Copy a workflow from one project to another.
+
+        Fetches the source workflow steps, validates the destination project has no labels,
+        deletes existing destination steps, and creates new steps with remapped sendBackStepId
+        references.
+        """
+        # 1. Fetch source workflow steps
+        logger.info("Fetching workflow steps from source project %s", source_project_id)
+        source_steps = self._kili_api_gateway.get_steps(source_project_id, _SOURCE_STEP_FIELDS)
+
+        if not source_steps:
+            raise ValueError(f"Source project {source_project_id} has no workflow steps to copy.")
+
+        # 2. Validate destination has no labels
+        self._validate_destination_has_no_labels(destination_project_id)
+
+        # 3. Get existing destination steps to delete
+        dest_step_ids = self._get_destination_step_ids(destination_project_id)
+
+        # 4. Build create steps and track sendBackStepId references
+        steps_to_create, source_steps_with_send_back = _build_steps_to_create(source_steps)
+
+        # 5. Execute: delete existing + create new steps in a single call
+        logger.info(
+            "Copying %d steps from project %s to project %s",
+            len(steps_to_create),
+            source_project_id,
+            destination_project_id,
+        )
+
+        result = self._kili_api_gateway.update_project_workflow(
+            destination_project_id,
+            ProjectWorkflowDataKiliAPIGatewayInput(
+                enforce_step_separation=None,
+                create_steps=steps_to_create,
+                update_steps=None,
+                delete_steps=dest_step_ids or None,
+            ),
+        )
+
+        # 6. Remap sendBackStepId references if any steps had them
+        if source_steps_with_send_back:
+            result = self._remap_send_back_step_ids(
+                source_steps, source_steps_with_send_back, destination_project_id
+            )
+
+        logger.info(
+            "Successfully copied workflow from project %s to project %s",
+            source_project_id,
+            destination_project_id,
+        )
+        return result
+
+    def _validate_destination_has_no_labels(self, destination_project_id: ProjectId) -> None:
+        """Validate that the destination project has no labels."""
+        logger.info(
+            "Validating destination project %s has no labels",
+            destination_project_id,
+        )
+        label_count = self._kili_api_gateway.count_labels(
+            filters=LabelFilters(project_id=destination_project_id)
+        )
+        if label_count > 0:
+            raise ValueError(
+                f"Destination project {destination_project_id} already has"
+                f" {label_count} label(s). Cannot copy workflow to a project"
+                " that has already been labeled."
+            )
+
+    def _get_destination_step_ids(self, destination_project_id: ProjectId) -> list[str]:
+        """Get existing step IDs from the destination project."""
+        logger.info(
+            "Fetching existing steps from destination project %s",
+            destination_project_id,
+        )
+        try:
+            dest_steps = self._kili_api_gateway.get_steps(
+                destination_project_id, ("steps.id", "steps.name")
+            )
+        except (ValueError, KeyError):
+            dest_steps = []
+        return [step["id"] for step in dest_steps]
+
+    def _remap_send_back_step_ids(
+        self,
+        source_steps: list[dict[str, object]],
+        source_steps_with_send_back: list[tuple[int, str]],
+        destination_project_id: ProjectId,
+    ) -> dict[str, object]:
+        """Remap sendBackStepId references from source to new destination step IDs."""
+        logger.info("Remapping sendBackStepId references for copied steps")
+
+        source_id_to_idx = {step["id"]: idx for idx, step in enumerate(source_steps)}
+        new_steps = self._kili_api_gateway.get_steps(
+            destination_project_id, ("steps.id", "steps.name")
+        )
+
+        name_to_new_id = {step["name"]: step["id"] for step in new_steps}
+        idx_to_name = {idx: step["name"] for idx, step in enumerate(source_steps)}
+
+        updates_for_send_back = _build_send_back_updates(
+            source_steps_with_send_back, source_id_to_idx, idx_to_name, name_to_new_id
+        )
+
+        if updates_for_send_back:
+            return self._kili_api_gateway.update_project_workflow(
+                destination_project_id,
+                ProjectWorkflowDataKiliAPIGatewayInput(
+                    enforce_step_separation=None,
+                    create_steps=None,
+                    update_steps=updates_for_send_back,
+                    delete_steps=None,
+                ),
+            )
+        return {}
+
+
+def _build_steps_to_create(
+    source_steps: list[dict[str, object]],
+) -> tuple[list[WorkflowStepCreate], list[tuple[int, str]]]:
+    """Build WorkflowStepCreate list from source steps and track sendBackStepId references."""
+    steps_to_create: list[WorkflowStepCreate] = []
+    source_steps_with_send_back: list[tuple[int, str]] = []
+
+    for idx, step in enumerate(source_steps):
+        create_step: WorkflowStepCreate = {
+            "name": step["name"],
+            "type": step["type"],
+            "assignees": [],  # Don't copy assignees per spec
+        }
+        if step.get("consensusCoverage") is not None:
+            create_step["consensus_coverage"] = step["consensusCoverage"]
+        if step.get("numberOfExpectedLabelsForConsensus") is not None:
+            create_step["number_of_expected_labels_for_consensus"] = step[
+                "numberOfExpectedLabelsForConsensus"
+            ]
+        if step.get("stepCoverage") is not None:
+            create_step["step_coverage"] = step["stepCoverage"]
+
+        if step.get("sendBackStepId"):
+            source_steps_with_send_back.append((idx, step["sendBackStepId"]))
+
+        steps_to_create.append(create_step)
+
+    return steps_to_create, source_steps_with_send_back
+
+
+def _build_send_back_updates(
+    source_steps_with_send_back: list[tuple[int, str]],
+    source_id_to_idx: dict[str, int],
+    idx_to_name: dict[int, str],
+    name_to_new_id: dict[str, str],
+) -> list[WorkflowStepUpdate]:
+    """Build WorkflowStepUpdate list for sendBackStepId remapping."""
+    updates: list[WorkflowStepUpdate] = []
+    for step_idx, source_send_back_id in source_steps_with_send_back:
+        target_source_idx = source_id_to_idx.get(source_send_back_id)
+        if target_source_idx is None:
+            logger.warning(
+                "Could not find source step for sendBackStepId %s, skipping",
+                source_send_back_id,
+            )
+            continue
+
+        step_name = idx_to_name[step_idx]
+        target_name = idx_to_name[target_source_idx]
+        new_step_id = name_to_new_id.get(step_name)
+        new_target_id = name_to_new_id.get(target_name)
+
+        if new_step_id and new_target_id:
+            updates.append(
+                {
+                    "id": new_step_id,
+                    "send_back_step_id": new_target_id,
+                }
+            )
+    return updates

--- a/tests/unit/use_cases/project_workflow/test_copy_workflow.py
+++ b/tests/unit/use_cases/project_workflow/test_copy_workflow.py
@@ -197,3 +197,46 @@ class TestCopyWorkflowFromProject:
         data = update_call[0][1]
         for step in data.create_steps:
             assert step["assignees"] == []
+
+    def test_raises_when_source_and_destination_are_same(self, use_cases, mock_gateway):
+        """Test that ValueError is raised when source and destination are the same project."""
+        project_id = ProjectId("same-project")
+
+        with pytest.raises(ValueError, match="must be different"):
+            use_cases.copy_workflow_from_project(
+                source_project_id=project_id,
+                destination_project_id=project_id,
+            )
+
+    def test_raises_when_source_has_duplicate_step_names(self, use_cases, mock_gateway):
+        """Test that ValueError is raised when source has duplicate step names."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        duplicate_steps = [
+            {
+                "id": "step-1",
+                "name": "Labeling",
+                "type": "DEFAULT",
+                "consensusCoverage": None,
+                "numberOfExpectedLabelsForConsensus": None,
+                "stepCoverage": None,
+                "sendBackStepId": None,
+            },
+            {
+                "id": "step-2",
+                "name": "Labeling",
+                "type": "DEFAULT",
+                "consensusCoverage": None,
+                "numberOfExpectedLabelsForConsensus": None,
+                "stepCoverage": None,
+                "sendBackStepId": None,
+            },
+        ]
+        mock_gateway.get_steps.return_value = duplicate_steps
+
+        with pytest.raises(ValueError, match="duplicate step names"):
+            use_cases.copy_workflow_from_project(
+                source_project_id=source_id,
+                destination_project_id=dest_id,
+            )

--- a/tests/unit/use_cases/project_workflow/test_copy_workflow.py
+++ b/tests/unit/use_cases/project_workflow/test_copy_workflow.py
@@ -48,6 +48,27 @@ def _make_source_steps(
     ]
 
 
+_DEST_USERS = [
+    {"role": "REVIEWER", "user": {"id": "user-reviewer-1"}},
+    {"role": "LABELER", "user": {"id": "user-labeler-1"}},
+    {"role": "REVIEWER", "user": {"id": "user-reviewer-2"}},
+]
+_LABELER_IDS = ["user-reviewer-1", "user-labeler-1", "user-reviewer-2"]
+_REVIEWER_IDS = ["user-reviewer-1", "user-reviewer-2"]  # role != LABELER
+
+
+def _setup_happy_path(mock_gateway, *, enforce_step_separation: bool | None = None) -> None:
+    """Configure common gateway mocks for tests that pass all validations."""
+    mock_gateway.get_project.side_effect = [
+        {"enforceStepSeparation": enforce_step_separation},  # source project fetch
+        {"workflowVersion": "V2"},  # destination V2 validation
+    ]
+    mock_gateway.count_labels.return_value = 0
+    # >= numberOfExpectedLabelsForConsensus (3)
+    mock_gateway.count_activated_project_users.return_value = 3
+    mock_gateway.list_activated_project_users.return_value = _DEST_USERS
+
+
 class TestCopyWorkflowFromProject:
     """Tests for copy_workflow_from_project."""
 
@@ -60,8 +81,7 @@ class TestCopyWorkflowFromProject:
             _make_source_steps(),  # source steps
             [{"id": "dest-step-old", "name": "Old Step"}],  # dest steps (1 step)
         ]
-        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
-        mock_gateway.count_labels.return_value = 0
+        _setup_happy_path(mock_gateway)
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
         }
@@ -83,7 +103,6 @@ class TestCopyWorkflowFromProject:
         assert data.update_steps is not None and len(data.update_steps) == 1
         assert data.update_steps[0]["id"] == "dest-step-old"
         assert data.update_steps[0]["name"] == "Labeling"
-        assert data.update_steps[0]["type"] == "DEFAULT"
         assert data.update_steps[0]["consensus_coverage"] == 50
 
         # Remaining source steps → create new
@@ -94,6 +113,29 @@ class TestCopyWorkflowFromProject:
 
         # No dest steps to delete (only 1 dest step, which was updated)
         assert data.delete_steps is None
+
+    def test_copies_enforce_step_separation(self, use_cases, mock_gateway):
+        """Test that enforce_step_separation is copied from the source project."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.side_effect = [
+            _make_source_steps(),
+            [{"id": "dest-step-old", "name": "Old Step"}],
+        ]
+        _setup_happy_path(mock_gateway, enforce_step_separation=True)
+        mock_gateway.update_project_workflow.return_value = {
+            "editProjectWorkflowSettings": {"steps": []}
+        }
+
+        use_cases.copy_workflow_from_project(
+            source_project_id=source_id,
+            destination_project_id=dest_id,
+        )
+
+        update_call = mock_gateway.update_project_workflow.call_args
+        data = update_call[0][1]
+        assert data.enforce_step_separation is True
 
     def test_raises_when_source_has_no_steps(self, use_cases, mock_gateway):
         """Test that ValueError is raised when source has no workflow steps."""
@@ -114,7 +156,10 @@ class TestCopyWorkflowFromProject:
         dest_id = ProjectId("dest-project")
 
         mock_gateway.get_steps.return_value = _make_source_steps()
-        mock_gateway.get_project.return_value = {"workflowVersion": "V1"}
+        mock_gateway.get_project.side_effect = [
+            {"enforceStepSeparation": None},  # source project fetch
+            {"workflowVersion": "V1"},  # destination V2 validation
+        ]
 
         with pytest.raises(ValueError, match="workflow version"):
             use_cases.copy_workflow_from_project(
@@ -128,7 +173,10 @@ class TestCopyWorkflowFromProject:
         dest_id = ProjectId("dest-project")
 
         mock_gateway.get_steps.return_value = _make_source_steps()
-        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
+        mock_gateway.get_project.side_effect = [
+            {"enforceStepSeparation": None},
+            {"workflowVersion": "V2"},
+        ]
         mock_gateway.count_labels.return_value = 5
 
         with pytest.raises(ValueError, match="already has 5 label"):
@@ -136,6 +184,62 @@ class TestCopyWorkflowFromProject:
                 source_project_id=source_id,
                 destination_project_id=dest_id,
             )
+
+    def test_raises_when_destination_has_too_few_labelers(self, use_cases, mock_gateway):
+        """Test that ValueError is raised when destination lacks labelers for consensus."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.return_value = _make_source_steps()  # first step requires 3
+        mock_gateway.get_project.side_effect = [
+            {"enforceStepSeparation": None},
+            {"workflowVersion": "V2"},
+        ]
+        mock_gateway.count_labels.return_value = 0
+        # 2 is fewer than the required 3
+        mock_gateway.count_activated_project_users.return_value = 2
+
+        with pytest.raises(ValueError, match="2 activated labeler"):
+            use_cases.copy_workflow_from_project(
+                source_project_id=source_id,
+                destination_project_id=dest_id,
+            )
+
+    def test_skips_consensus_check_when_not_set(self, use_cases, mock_gateway):
+        """Test consensus labeler check is skipped when numberOfExpectedLabelsForConsensus is None."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        steps_without_consensus = [
+            {
+                "id": "source-step-1",
+                "name": "Labeling",
+                "type": "DEFAULT",
+                "consensusCoverage": None,
+                "numberOfExpectedLabelsForConsensus": None,
+                "stepCoverage": None,
+                "sendBackStepId": None,
+            }
+        ]
+        mock_gateway.get_steps.side_effect = [
+            steps_without_consensus,
+            [{"id": "dest-old", "name": "Old"}],
+        ]
+        mock_gateway.get_project.side_effect = [
+            {"enforceStepSeparation": None},
+            {"workflowVersion": "V2"},
+        ]
+        mock_gateway.count_labels.return_value = 0
+        mock_gateway.update_project_workflow.return_value = {
+            "editProjectWorkflowSettings": {"steps": []}
+        }
+
+        use_cases.copy_workflow_from_project(
+            source_project_id=source_id,
+            destination_project_id=dest_id,
+        )
+
+        mock_gateway.count_activated_project_users.assert_not_called()
 
     def test_remaps_send_back_step_id(self, use_cases, mock_gateway):
         """Test that sendBackStepId is remapped to new step IDs."""
@@ -151,8 +255,7 @@ class TestCopyWorkflowFromProject:
                 {"id": "new-step-2", "name": "Review"},
             ],
         ]
-        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
-        mock_gateway.count_labels.return_value = 0
+        _setup_happy_path(mock_gateway)
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
         }
@@ -187,8 +290,7 @@ class TestCopyWorkflowFromProject:
                 {"id": "dest-step-3", "name": "Step3"},
             ],
         ]
-        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
-        mock_gateway.count_labels.return_value = 0
+        _setup_happy_path(mock_gateway)
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
         }
@@ -215,8 +317,7 @@ class TestCopyWorkflowFromProject:
             raise ValueError("No workflow found")
 
         mock_gateway.get_steps.side_effect = get_steps_side_effect
-        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
-        mock_gateway.count_labels.return_value = 0
+        _setup_happy_path(mock_gateway)
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
         }
@@ -233,17 +334,16 @@ class TestCopyWorkflowFromProject:
         assert data.create_steps is not None and len(data.create_steps) == 2
         assert data.delete_steps is None
 
-    def test_does_not_copy_assignees(self, use_cases, mock_gateway):
-        """Test that assignees are not copied: neither update nor create steps include them."""
+    def test_assignees_use_dest_project_users(self, use_cases, mock_gateway):
+        """Test that created steps use destination project users, not source assignees."""
         source_id = ProjectId("source-project")
         dest_id = ProjectId("dest-project")
 
         mock_gateway.get_steps.side_effect = [
-            _make_source_steps(),
+            _make_source_steps(),  # source: DEFAULT + REVIEW
             [{"id": "dest-old", "name": "Old"}],
         ]
-        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
-        mock_gateway.count_labels.return_value = 0
+        _setup_happy_path(mock_gateway)
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
         }
@@ -255,10 +355,16 @@ class TestCopyWorkflowFromProject:
 
         update_call = mock_gateway.update_project_workflow.call_args
         data = update_call[0][1]
-        for step in (data.update_steps or []) + (data.create_steps or []):
-            assert "assignees" not in step
 
-    def test_raises_when_source_and_destination_are_same(self, use_cases, mock_gateway):
+        # update_steps (first DEFAULT step): no assignees on update
+        assert data.update_steps is not None
+        assert "assignees" not in data.update_steps[0]
+
+        # create_steps (REVIEW step): reviewer_ids only (role != LABELER)
+        assert data.create_steps is not None
+        assert data.create_steps[0]["assignees"] == _REVIEWER_IDS
+
+    def test_raises_when_source_and_destination_are_same(self, use_cases):
         """Test that ValueError is raised when source and destination are the same project."""
         project_id = ProjectId("same-project")
 

--- a/tests/unit/use_cases/project_workflow/test_copy_workflow.py
+++ b/tests/unit/use_cases/project_workflow/test_copy_workflow.py
@@ -1,0 +1,199 @@
+"""Tests for copy_workflow_from_project use case."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kili.domain.label import LabelFilters
+from kili.domain.project import ProjectId
+from kili.use_cases.project_workflow import ProjectWorkflowUseCases
+
+
+@pytest.fixture()
+def mock_gateway():
+    """Create a mock KiliAPIGateway."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def use_cases(mock_gateway):
+    """Create ProjectWorkflowUseCases with mocked gateway."""
+    return ProjectWorkflowUseCases(mock_gateway)
+
+
+def _make_source_steps(
+    *,
+    with_send_back: bool = False,
+) -> list[dict]:
+    """Create sample source steps."""
+    return [
+        {
+            "id": "source-step-1",
+            "name": "Labeling",
+            "type": "DEFAULT",
+            "consensusCoverage": 50,
+            "numberOfExpectedLabelsForConsensus": 3,
+            "stepCoverage": None,
+            "sendBackStepId": None,
+        },
+        {
+            "id": "source-step-2",
+            "name": "Review",
+            "type": "REVIEW",
+            "consensusCoverage": None,
+            "numberOfExpectedLabelsForConsensus": None,
+            "stepCoverage": 80,
+            "sendBackStepId": "source-step-1" if with_send_back else None,
+        },
+    ]
+
+
+class TestCopyWorkflowFromProject:
+    """Tests for copy_workflow_from_project."""
+
+    def test_copies_basic_workflow(self, use_cases, mock_gateway):
+        """Test copying a basic workflow without sendBackStepId."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.side_effect = [
+            _make_source_steps(),  # source steps
+            [{"id": "dest-step-old", "name": "Old Step"}],  # dest steps
+        ]
+        mock_gateway.count_labels.return_value = 0
+        mock_gateway.update_project_workflow.return_value = {
+            "editProjectWorkflowSettings": {"steps": []}
+        }
+
+        use_cases.copy_workflow_from_project(
+            source_project_id=source_id,
+            destination_project_id=dest_id,
+        )
+
+        # Verify label count check
+        mock_gateway.count_labels.assert_called_once_with(filters=LabelFilters(project_id=dest_id))
+
+        # Verify update call
+        update_call = mock_gateway.update_project_workflow.call_args
+        assert update_call[0][0] == dest_id
+        data = update_call[0][1]
+        assert len(data.create_steps) == 2
+        assert data.create_steps[0]["name"] == "Labeling"
+        assert data.create_steps[0]["type"] == "DEFAULT"
+        assert data.create_steps[0]["assignees"] == []
+        assert data.create_steps[0]["consensus_coverage"] == 50
+        assert data.create_steps[1]["name"] == "Review"
+        assert data.create_steps[1]["type"] == "REVIEW"
+        assert data.create_steps[1]["step_coverage"] == 80
+        assert data.delete_steps == ["dest-step-old"]
+
+    def test_raises_when_source_has_no_steps(self, use_cases, mock_gateway):
+        """Test that ValueError is raised when source has no workflow steps."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.return_value = []
+
+        with pytest.raises(ValueError, match="has no workflow steps"):
+            use_cases.copy_workflow_from_project(
+                source_project_id=source_id,
+                destination_project_id=dest_id,
+            )
+
+    def test_raises_when_destination_has_labels(self, use_cases, mock_gateway):
+        """Test that ValueError is raised when destination has labels."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.return_value = _make_source_steps()
+        mock_gateway.count_labels.return_value = 5
+
+        with pytest.raises(ValueError, match="already has 5 label"):
+            use_cases.copy_workflow_from_project(
+                source_project_id=source_id,
+                destination_project_id=dest_id,
+            )
+
+    def test_remaps_send_back_step_id(self, use_cases, mock_gateway):
+        """Test that sendBackStepId is remapped to new step IDs."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.side_effect = [
+            _make_source_steps(with_send_back=True),
+            [{"id": "dest-old", "name": "OldStep"}],
+            [
+                {"id": "new-step-1", "name": "Labeling"},
+                {"id": "new-step-2", "name": "Review"},
+            ],
+        ]
+        mock_gateway.count_labels.return_value = 0
+        mock_gateway.update_project_workflow.return_value = {
+            "editProjectWorkflowSettings": {"steps": []}
+        }
+
+        use_cases.copy_workflow_from_project(
+            source_project_id=source_id,
+            destination_project_id=dest_id,
+        )
+
+        # Should have been called twice: once for create, once for sendBackStepId update
+        assert mock_gateway.update_project_workflow.call_count == 2
+
+        # Verify the second call remaps sendBackStepId
+        second_call = mock_gateway.update_project_workflow.call_args_list[1]
+        data = second_call[0][1]
+        assert data.update_steps is not None
+        assert len(data.update_steps) == 1
+        assert data.update_steps[0]["id"] == "new-step-2"
+        assert data.update_steps[0]["send_back_step_id"] == "new-step-1"
+
+    def test_handles_destination_without_existing_workflow(self, use_cases, mock_gateway):
+        """Test copying to a project that has no existing workflow."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        def get_steps_side_effect(project_id, fields) -> list:
+            if project_id == source_id:
+                return _make_source_steps()
+            raise ValueError("No workflow found")
+
+        mock_gateway.get_steps.side_effect = get_steps_side_effect
+        mock_gateway.count_labels.return_value = 0
+        mock_gateway.update_project_workflow.return_value = {
+            "editProjectWorkflowSettings": {"steps": []}
+        }
+
+        use_cases.copy_workflow_from_project(
+            source_project_id=source_id,
+            destination_project_id=dest_id,
+        )
+
+        # Verify update was called with no deletes
+        update_call = mock_gateway.update_project_workflow.call_args
+        data = update_call[0][1]
+        assert data.delete_steps is None
+
+    def test_does_not_copy_assignees(self, use_cases, mock_gateway):
+        """Test that assignees are not copied from source steps."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.side_effect = [
+            _make_source_steps(),
+            [{"id": "old", "name": "Old"}],
+        ]
+        mock_gateway.count_labels.return_value = 0
+        mock_gateway.update_project_workflow.return_value = {
+            "editProjectWorkflowSettings": {"steps": []}
+        }
+
+        use_cases.copy_workflow_from_project(
+            source_project_id=source_id,
+            destination_project_id=dest_id,
+        )
+
+        update_call = mock_gateway.update_project_workflow.call_args
+        data = update_call[0][1]
+        for step in data.create_steps:
+            assert step["assignees"] == []

--- a/tests/unit/use_cases/project_workflow/test_copy_workflow.py
+++ b/tests/unit/use_cases/project_workflow/test_copy_workflow.py
@@ -52,14 +52,15 @@ class TestCopyWorkflowFromProject:
     """Tests for copy_workflow_from_project."""
 
     def test_copies_basic_workflow(self, use_cases, mock_gateway):
-        """Test copying a basic workflow without sendBackStepId."""
+        """Test copying a basic workflow: first dest step is updated, remaining are created."""
         source_id = ProjectId("source-project")
         dest_id = ProjectId("dest-project")
 
         mock_gateway.get_steps.side_effect = [
             _make_source_steps(),  # source steps
-            [{"id": "dest-step-old", "name": "Old Step"}],  # dest steps
+            [{"id": "dest-step-old", "name": "Old Step"}],  # dest steps (1 step)
         ]
+        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
         mock_gateway.count_labels.return_value = 0
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
@@ -77,15 +78,22 @@ class TestCopyWorkflowFromProject:
         update_call = mock_gateway.update_project_workflow.call_args
         assert update_call[0][0] == dest_id
         data = update_call[0][1]
-        assert len(data.create_steps) == 2
-        assert data.create_steps[0]["name"] == "Labeling"
-        assert data.create_steps[0]["type"] == "DEFAULT"
-        assert data.create_steps[0]["assignees"] == []
-        assert data.create_steps[0]["consensus_coverage"] == 50
-        assert data.create_steps[1]["name"] == "Review"
-        assert data.create_steps[1]["type"] == "REVIEW"
-        assert data.create_steps[1]["step_coverage"] == 80
-        assert data.delete_steps == ["dest-step-old"]
+
+        # First source step → update the existing first dest step
+        assert data.update_steps is not None and len(data.update_steps) == 1
+        assert data.update_steps[0]["id"] == "dest-step-old"
+        assert data.update_steps[0]["name"] == "Labeling"
+        assert data.update_steps[0]["type"] == "DEFAULT"
+        assert data.update_steps[0]["consensus_coverage"] == 50
+
+        # Remaining source steps → create new
+        assert data.create_steps is not None and len(data.create_steps) == 1
+        assert data.create_steps[0]["name"] == "Review"
+        assert data.create_steps[0]["type"] == "REVIEW"
+        assert data.create_steps[0]["step_coverage"] == 80
+
+        # No dest steps to delete (only 1 dest step, which was updated)
+        assert data.delete_steps is None
 
     def test_raises_when_source_has_no_steps(self, use_cases, mock_gateway):
         """Test that ValueError is raised when source has no workflow steps."""
@@ -100,12 +108,27 @@ class TestCopyWorkflowFromProject:
                 destination_project_id=dest_id,
             )
 
+    def test_raises_when_destination_is_not_workflow_v2(self, use_cases, mock_gateway):
+        """Test that ValueError is raised when destination project is not workflow V2."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        mock_gateway.get_steps.return_value = _make_source_steps()
+        mock_gateway.get_project.return_value = {"workflowVersion": "V1"}
+
+        with pytest.raises(ValueError, match="workflow version"):
+            use_cases.copy_workflow_from_project(
+                source_project_id=source_id,
+                destination_project_id=dest_id,
+            )
+
     def test_raises_when_destination_has_labels(self, use_cases, mock_gateway):
         """Test that ValueError is raised when destination has labels."""
         source_id = ProjectId("source-project")
         dest_id = ProjectId("dest-project")
 
         mock_gateway.get_steps.return_value = _make_source_steps()
+        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
         mock_gateway.count_labels.return_value = 5
 
         with pytest.raises(ValueError, match="already has 5 label"):
@@ -121,12 +144,14 @@ class TestCopyWorkflowFromProject:
 
         mock_gateway.get_steps.side_effect = [
             _make_source_steps(with_send_back=True),
-            [{"id": "dest-old", "name": "OldStep"}],
+            [{"id": "dest-old", "name": "OldStep"}],  # 1 existing dest step
+            # After update+create, dest has: updated first step + new Review step
             [
-                {"id": "new-step-1", "name": "Labeling"},
+                {"id": "dest-old", "name": "Labeling"},
                 {"id": "new-step-2", "name": "Review"},
             ],
         ]
+        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
         mock_gateway.count_labels.return_value = 0
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
@@ -137,7 +162,7 @@ class TestCopyWorkflowFromProject:
             destination_project_id=dest_id,
         )
 
-        # Should have been called twice: once for create, once for sendBackStepId update
+        # Should have been called twice: once for update/create, once for sendBackStepId remap
         assert mock_gateway.update_project_workflow.call_count == 2
 
         # Verify the second call remaps sendBackStepId
@@ -145,20 +170,52 @@ class TestCopyWorkflowFromProject:
         data = second_call[0][1]
         assert data.update_steps is not None
         assert len(data.update_steps) == 1
+        # Review step's sendBackStepId should point to Labeling (dest-old)
         assert data.update_steps[0]["id"] == "new-step-2"
-        assert data.update_steps[0]["send_back_step_id"] == "new-step-1"
+        assert data.update_steps[0]["send_back_step_id"] == "dest-old"
 
-    def test_handles_destination_without_existing_workflow(self, use_cases, mock_gateway):
-        """Test copying to a project that has no existing workflow."""
+    def test_deletes_extra_dest_steps(self, use_cases, mock_gateway):
+        """Test that extra dest steps beyond the first are deleted."""
         source_id = ProjectId("source-project")
         dest_id = ProjectId("dest-project")
 
-        def get_steps_side_effect(project_id, fields) -> list:
+        mock_gateway.get_steps.side_effect = [
+            _make_source_steps(),  # source: 2 steps
+            [  # dest: 3 existing steps
+                {"id": "dest-step-1", "name": "Step1"},
+                {"id": "dest-step-2", "name": "Step2"},
+                {"id": "dest-step-3", "name": "Step3"},
+            ],
+        ]
+        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
+        mock_gateway.count_labels.return_value = 0
+        mock_gateway.update_project_workflow.return_value = {
+            "editProjectWorkflowSettings": {"steps": []}
+        }
+
+        use_cases.copy_workflow_from_project(
+            source_project_id=source_id,
+            destination_project_id=dest_id,
+        )
+
+        update_call = mock_gateway.update_project_workflow.call_args
+        data = update_call[0][1]
+        # First dest step updated, other two deleted
+        assert data.update_steps is not None and data.update_steps[0]["id"] == "dest-step-1"
+        assert set(data.delete_steps) == {"dest-step-2", "dest-step-3"}
+
+    def test_handles_destination_without_existing_workflow(self, use_cases, mock_gateway):
+        """Test copying to a project that has no existing workflow (creates all steps)."""
+        source_id = ProjectId("source-project")
+        dest_id = ProjectId("dest-project")
+
+        def get_steps_side_effect(project_id, _fields) -> list:
             if project_id == source_id:
                 return _make_source_steps()
             raise ValueError("No workflow found")
 
         mock_gateway.get_steps.side_effect = get_steps_side_effect
+        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
         mock_gateway.count_labels.return_value = 0
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
@@ -169,20 +226,23 @@ class TestCopyWorkflowFromProject:
             destination_project_id=dest_id,
         )
 
-        # Verify update was called with no deletes
         update_call = mock_gateway.update_project_workflow.call_args
         data = update_call[0][1]
+        # No dest steps → create all, no updates, no deletes
+        assert data.update_steps is None
+        assert data.create_steps is not None and len(data.create_steps) == 2
         assert data.delete_steps is None
 
     def test_does_not_copy_assignees(self, use_cases, mock_gateway):
-        """Test that assignees are not copied from source steps."""
+        """Test that assignees are not copied: neither update nor create steps include them."""
         source_id = ProjectId("source-project")
         dest_id = ProjectId("dest-project")
 
         mock_gateway.get_steps.side_effect = [
             _make_source_steps(),
-            [{"id": "old", "name": "Old"}],
+            [{"id": "dest-old", "name": "Old"}],
         ]
+        mock_gateway.get_project.return_value = {"workflowVersion": "V2"}
         mock_gateway.count_labels.return_value = 0
         mock_gateway.update_project_workflow.return_value = {
             "editProjectWorkflowSettings": {"steps": []}
@@ -195,8 +255,8 @@ class TestCopyWorkflowFromProject:
 
         update_call = mock_gateway.update_project_workflow.call_args
         data = update_call[0][1]
-        for step in data.create_steps:
-            assert step["assignees"] == []
+        for step in (data.update_steps or []) + (data.create_steps or []):
+            assert "assignees" not in step
 
     def test_raises_when_source_and_destination_are_same(self, use_cases, mock_gateway):
         """Test that ValueError is raised when source and destination are the same project."""


### PR DESCRIPTION
Add a high-level method to copy a workflow from one project to another, including step configurations (consensus, coverage, sendBackStepId).

- Add `copy_workflow_from_project` to presentation client and use cases
- Add `send_back_step_id` field to WorkflowStepCreate and WorkflowStepUpdate
- Add `sendBackStepId` mapping in the GraphQL step mapper
- Validate destination project has no labels before copying
- Remap sendBackStepId references to new step IDs after creation
- Don't copy assignees per specification
- Add unit tests for all scenarios

