### PR TITLE
fix(LAB-4524): always use jsonResponseUrl for all types except LLM to…

### DIFF
--- a/src/kili/adapters/kili_api_gateway/asset/operations_mixin.py
+++ b/src/kili/adapters/kili_api_gateway/asset/operations_mixin.py
@@ -54,15 +54,17 @@ class AssetOperationMixin(BaseOperationMixin):
             # TODO(LAB-4269): TEMPORARY WORKAROUND - Remove when backend handles jsonResponseUrl for LLM
             # Threshold for batching based on number of annotations.
             if project_info["inputType"] in {
-                "LLM_RLHF",
                 "LLM_INSTR_FOLLOWING",
                 "LLM_STATIC",
             }:
-                yield from self.llm_list_assets_split(filters, fields, options, project_info)
+                yield from self.llm_list_assets_without_json_response_from_bucket(
+                    filters, fields, options, project_info
+                )
                 return
-            if project_info["inputType"] in {"VIDEO", "GEOSPATIAL"}:
-                yield from self.list_assets_split(filters, fields, options, project_info)
-                return
+            yield from self.list_assets_with_json_response_from_bucket(
+                filters, fields, options, project_info
+            )
+            return
 
         fragment = fragment_builder(fields)
         query = get_assets_query(fragment)
@@ -81,14 +83,14 @@ class AssetOperationMixin(BaseOperationMixin):
 
         yield from assets_gen
 
-    def list_assets_split(
+    def list_assets_with_json_response_from_bucket(
         self,
         filters: AssetFilters,
         fields: ListOrTuple[str],
         options: QueryOptions,
         project_info,
     ) -> Generator[dict, None, None]:
-        """List assets with given options for VIDEO and GEOSPATIAL projects."""
+        """List assets with given options for every non-LLM projects."""
         assets_batch_max_amount = 10 if project_info["inputType"] == "VIDEO" else 50
         batch_size_to_use = min(options.batch_size, assets_batch_max_amount)
 
@@ -121,7 +123,7 @@ class AssetOperationMixin(BaseOperationMixin):
 
         yield from assets_gen
 
-    def llm_list_assets_split(
+    def llm_list_assets_without_json_response_from_bucket(
         self,
         filters: AssetFilters,
         fields: ListOrTuple[str],

--- a/src/kili/adapters/kili_api_gateway/label/operations_mixin.py
+++ b/src/kili/adapters/kili_api_gateway/label/operations_mixin.py
@@ -59,15 +59,17 @@ class LabelOperationMixin(BaseOperationMixin):
             # TODO(LAB-4269): TEMPORARY WORKAROUND - Remove when backend handles jsonResponseUrl for LLM
             # Threshold for batching based on number of annotations.
             if project_info["inputType"] in {
-                "LLM_RLHF",
                 "LLM_INSTR_FOLLOWING",
                 "LLM_STATIC",
             }:
-                yield from self.llm_list_labels_split(filters, fields, options, project_info)
+                yield from self.llm_list_labels_without_json_response_from_bucket(
+                    filters, fields, options, project_info
+                )
                 return
-            if project_info["inputType"] in {"GEOSPATIAL", "VIDEO"}:
-                yield from self.list_labels_split(filters, fields, options, project_info)
-                return
+            yield from self.list_labels_with_json_response_from_bucket(
+                filters, fields, options, project_info
+            )
+            return
 
         fragment = fragment_builder(fields)
         query = get_labels_query(fragment)
@@ -80,14 +82,14 @@ class LabelOperationMixin(BaseOperationMixin):
         )
         yield from labels_gen
 
-    def list_labels_split(
+    def list_labels_with_json_response_from_bucket(
         self,
         filters: LabelFilters,
         fields: ListOrTuple[str],
         options: QueryOptions,
         project_info,
     ) -> Generator[dict, None, None]:
-        """List labels for VIDEO and GEOSPATIAL projects."""
+        """List labels for every non-LLM projects."""
         if project_info["inputType"] == "VIDEO":
             options = QueryOptions(
                 options.disable_tqdm, options.first, options.skip, min(options.batch_size, 20)
@@ -109,7 +111,7 @@ class LabelOperationMixin(BaseOperationMixin):
 
         yield from labels_gen
 
-    def llm_list_labels_split(
+    def llm_list_labels_without_json_response_from_bucket(
         self,
         filters: LabelFilters,
         fields: ListOrTuple[str],

--- a/src/kili/llm/services/export/__init__.py
+++ b/src/kili/llm/services/export/__init__.py
@@ -36,7 +36,6 @@ LABELS_NEEDED_FIELDS = [
     "isLatestLabelForUser",
     "isSentBackToQueue",
     "jsonResponse",  # This is needed to keep annotations
-    "jsonResponseUrl",
     "labelType",
     "modelName",
 ]

--- a/src/kili/services/copy_project/__init__.py
+++ b/src/kili/services/copy_project/__init__.py
@@ -205,7 +205,6 @@ class ProjectCopier:  # pylint: disable=too-few-public-methods
             fields=[
                 "author.email",
                 "jsonResponse",
-                "jsonResponseUrl",
                 "secondsToLabel",
                 "isLatestLabelForUser",
                 "labelOf.externalId",

--- a/tests/integration/adapters/kili_api_gateway/test_label.py
+++ b/tests/integration/adapters/kili_api_gateway/test_label.py
@@ -1,3 +1,4 @@
+import pytest
 import pytest_mock
 
 from kili.adapters.http_client import HttpClient
@@ -21,7 +22,11 @@ from kili.domain.asset.asset import AssetId
 from kili.domain.label import LabelFilters, LabelId
 from kili.domain.project import ProjectId
 from kili.domain.user import UserId
-from tests.unit.adapters.kili_api_gateway.label.test_data import test_case_1
+from tests.unit.adapters.kili_api_gateway.label.test_data import (
+    audio_test_case,
+    geospatial_test_case,
+    test_case_1,
+)
 
 
 def test_given_kili_gateway_when_querying_labels__it_calls_proper_resolver(
@@ -206,15 +211,27 @@ def test_given_kili_gateway_when_adding_labels_by_batch_then_it_calls_proper_res
     )
 
 
+@pytest.mark.parametrize(
+    ("input_type", "test_case"),
+    [
+        ("VIDEO", test_case_1),
+        ("GEOSPATIAL", geospatial_test_case),
+        ("AUDIO", audio_test_case),
+    ],
+)
 def test_given_project_with_new_annotations_when_calling_list_labels_it_converts_to_json_response(
-    graphql_client: GraphQLClient, http_client: HttpClient, mocker: pytest_mock.MockerFixture
+    input_type: str,
+    test_case,
+    graphql_client: GraphQLClient,
+    http_client: HttpClient,
+    mocker: pytest_mock.MockerFixture,
 ):
-    """For VIDEO projects, when jsonResponse is requested, it is fetched from jsonResponseUrl."""
+    """When jsonResponse is requested, it is fetched from jsonResponseUrl."""
 
     # Given
     def mocked_graphql_execute(query: str, variables: dict, **kwargs) -> dict:
         if "projects(" in query:
-            return {"data": [{"inputType": "VIDEO", "jsonInterface": test_case_1.json_interface}]}
+            return {"data": [{"inputType": input_type, "jsonInterface": test_case.json_interface}]}
 
         if "countLabels(" in query:
             return {"data": 1}
@@ -234,7 +251,7 @@ def test_given_project_with_new_annotations_when_calling_list_labels_it_converts
     graphql_client.execute.side_effect = mocked_graphql_execute
 
     mock_http_response = http_client.get.return_value
-    mock_http_response.json.return_value = test_case_1.expected_json_resp
+    mock_http_response.json.return_value = test_case.expected_json_resp
 
     kili_gateway = KiliAPIGateway(graphql_client=graphql_client, http_client=http_client)
 
@@ -248,5 +265,5 @@ def test_given_project_with_new_annotations_when_calling_list_labels_it_converts
     )
 
     # Then
-    assert labels[0]["jsonResponse"] == test_case_1.expected_json_resp
+    assert labels[0]["jsonResponse"] == test_case.expected_json_resp
     assert "jsonResponseUrl" not in labels[0]

--- a/tests/unit/adapters/kili_api_gateway/label/test_data/audio_test_case.py
+++ b/tests/unit/adapters/kili_api_gateway/label/test_data/audio_test_case.py
@@ -1,0 +1,52 @@
+"""AUDIO test case: asset-level classification + segment-level transcription.
+
+Audio projects only allow CLASSIFICATION and TRANSCRIPTION jobs (no detection).
+A non-child job is asset-level when it carries ``"level": "asset"`` and
+segment-level otherwise; audio projects require at least one segment-level
+transcription job. The jsonResponse is a flat, job-keyed dict (audio projects
+are not frame indexed): the asset-level classification holds a single category,
+the segment-level transcription holds time-bounded segments.
+"""
+
+json_interface = {
+    "jobs": {
+        # Asset-level classification (applies to the whole audio asset).
+        "CLASSIFICATION_JOB": {
+            "content": {
+                "categories": {
+                    "SPEECH": {"children": [], "name": "Speech"},
+                    "MUSIC": {"children": [], "name": "Music"},
+                },
+                "input": "radio",
+            },
+            "instruction": "Audio type",
+            "mlTask": "CLASSIFICATION",
+            "level": "asset",
+            "isChild": False,
+            "required": 1,
+        },
+        # Segment-level transcription (required for audio projects).
+        "TRANSCRIPTION_JOB": {
+            "content": {"input": "textField"},
+            "instruction": "Transcribe the audio",
+            "mlTask": "TRANSCRIPTION",
+            "isChild": False,
+            "required": 0,
+        },
+    }
+}
+
+expected_json_resp = {
+    "CLASSIFICATION_JOB": {"categories": [{"name": "SPEECH"}]},
+    "TRANSCRIPTION_JOB": {
+        "annotations": [
+            {
+                "children": {},
+                "text": "the quick brown fox",
+                "startTime": 0.0,
+                "endTime": 2.5,
+                "mid": "20231031123948352-1",
+            }
+        ]
+    },
+}

--- a/tests/unit/adapters/kili_api_gateway/label/test_data/geospatial_test_case.py
+++ b/tests/unit/adapters/kili_api_gateway/label/test_data/geospatial_test_case.py
@@ -1,0 +1,72 @@
+"""GEOSPATIAL test case: object detection on a geoTIFF (no frames).
+
+The jsonResponse is a flat, job-keyed dict (there is no frame indexing for
+geospatial projects) with coordinates expressed as longitude/latitude.
+"""
+
+json_interface = {
+    "jobs": {
+        "BUILDING_DETECTION_JOB": {
+            "content": {
+                "categories": {
+                    "BUILDING": {"children": [], "name": "Building", "color": "#733AFB"},
+                },
+                "input": "radio",
+            },
+            "instruction": "Detect buildings",
+            "isChild": False,
+            "tools": ["polygon"],
+            "mlTask": "OBJECT_DETECTION",
+            "isVisible": True,
+            "required": 0,
+        },
+        "TREE_JOB": {
+            "content": {
+                "categories": {
+                    "TREE": {"children": [], "name": "Tree", "color": "#3CD876"},
+                },
+                "input": "radio",
+            },
+            "instruction": "Locate trees",
+            "isChild": False,
+            "tools": ["marker"],
+            "mlTask": "OBJECT_DETECTION",
+            "isVisible": True,
+            "required": 0,
+        },
+    }
+}
+
+expected_json_resp = {
+    "BUILDING_DETECTION_JOB": {
+        "annotations": [
+            {
+                "children": {},
+                "boundingPoly": [
+                    {
+                        "normalizedVertices": [
+                            {"x": 4.398223, "y": 52.248060},
+                            {"x": 4.398512, "y": 52.248060},
+                            {"x": 4.398512, "y": 52.248341},
+                            {"x": 4.398223, "y": 52.248341},
+                        ]
+                    }
+                ],
+                "categories": [{"name": "BUILDING"}],
+                "mid": "20231031123948352-1",
+                "type": "polygon",
+            }
+        ]
+    },
+    "TREE_JOB": {
+        "annotations": [
+            {
+                "children": {},
+                "point": {"x": 4.371029, "y": 52.241662},
+                "categories": [{"name": "TREE"}],
+                "mid": "20231031123948352-2",
+                "type": "marker",
+            }
+        ]
+    },
+}


### PR DESCRIPTION
… retrieve labels

